### PR TITLE
Remove problematic service changes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1631,13 +1631,6 @@ MemoryLimit=512M
 CPUQuota=50%
 TasksMax=200
 
-# Security and isolation
-NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=$INSTALL_DIR
-
 # Logging
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Something in this section seems to have caused some issues for recrof on Debian. Didn't drill into which ones, removed the whole section and the service worked. With them, the service did not work - but replicating the environmne/context was fine. Unsure if Debian specific or would also happen on Pi, as I did not test.