### PR TITLE
Docker nvm install location fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip cache purge
 
 # Install Node.js via nvm and meshcore-decoder for auth token support
-ENV NVM_DIR=/root/.nvm
+ENV NVM_DIR=/opt/nvm
 ENV NODE_VERSION=lts/*
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
+RUN mkdir -p "$NVM_DIR" && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . "$NVM_DIR/nvm.sh" \
     && nvm install $NODE_VERSION \
     && nvm use $NODE_VERSION \


### PR DESCRIPTION
Changes the install location to somewhere other than the root homedir.

Without this change the result is `Not authorized` errors while connecting to Tree's MQTT server. It works in `Cisien/meshcoretomqtt` because that image runs as root. 


Particle Forest is currently running the result of this change:

<img width="1036" height="666" alt="particle_forest" src="https://github.com/user-attachments/assets/1698d2a5-7a87-45d6-8aca-e752e9c53b97" />
