### PR TITLE
Add device listing for FreeBSD

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,11 @@ detect_serial_devices() {
         while IFS= read -r device; do
             devices+=("$device")
         done < <(ls /dev/cu.usb* /dev/cu.wchusbserial* /dev/cu.SLAB_USBtoUART* 2>/dev/null | sort)
+    elif [ "$(uname)" = "FreeBSD" ]; then
+        # FreeBSD: Use /dev/cuaU* devices (callout devices, preferred over ttyU*)
+        while IFS= read -r device; do
+            devices+=("$device")
+        done < <(ls /dev/cuaU* | grep -v -E '\.(lock|init)$' 2>/dev/null | sort)
     else
         # Linux: Prefer /dev/serial/by-id/ for persistent naming
         if [ -d /dev/serial/by-id ]; then


### PR DESCRIPTION
Fix serial selection for FreeBSD. Most (all?) USB adapters use `/dev/ttyU*` and `/dev/cuaU*`. The`cuaU` is preferred as the `dialer` group owns it, so it is easier to provide access to non-root. 