### PR TITLE
Align advert and control parsing with MeshCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ This setting allows you to filter which packet types are uploaded to MQTT broker
 - `8` = PATH
 - `9` = TRACE
 - `10` = MULTIPART
-- `11-14` = Reserved
+- `11` = CONTROL
+- `12-14` = Reserved
 - `15` = RAW_CUSTOM
 
 **Examples:**

--- a/enums.py
+++ b/enums.py
@@ -42,7 +42,7 @@ class PayloadType(Enum):
     PATH = 0x08         # PAYLOAD_TYPE_PATH
     TRACE = 0x09        # PAYLOAD_TYPE_TRACE
     MULTIPART = 0x0A    # PAYLOAD_TYPE_MULTIPART
-    Type11 = 0x0B       # Reserved
+    CONTROL = 0x0B      # PAYLOAD_TYPE_CONTROL
     Type12 = 0x0C       # Reserved
     Type13 = 0x0D       # Reserved
     Type14 = 0x0E       # Reserved

--- a/packet_capture.py
+++ b/packet_capture.py
@@ -2684,7 +2684,8 @@ class PacketCapture:
             
             if payload_type is PayloadType.ADVERT:
                 key_prefix = payload_value["public_key"][:2]
-                if payload_value["name"].endswith("^"):
+                name = payload_value.get("name", "")
+                if name.endswith("^"):
                     message.update(payload_value)
                 elif key_prefix not in self.opted_in_ids:
                     self.opted_in_ids.append(key_prefix)
@@ -2838,7 +2839,7 @@ class PacketCapture:
                 "PATH": "8",
                 "TRACE": "9",
                 "MULTIPART": "10",
-                "Type11": "11",
+                "CONTROL": "11",
                 "Type12": "12",
                 "Type13": "13",
                 "Type14": "14",


### PR DESCRIPTION
## Summary
- avoid assuming every advert includes a name
- rename payload type `0x0B` to `CONTROL` to match current MeshCore protocol
- align packet type docs with the current MeshCore payload map

## Validation
- python3 -m py_compile packet_capture.py enums.py
