### PR TITLE
Preserve decoded advert metadata

### DIFF
--- a/packet_capture.py
+++ b/packet_capture.py
@@ -276,9 +276,6 @@ class PacketCapture:
         self.rf_data_cache = {}
         self.packet_count = 0
         
-        # Opted-in IDs for advert filtering (mirroring mctomqtt.py)
-        self.opted_in_ids = []
-        
         # Device information
         self.device_name = None
         self.device_public_key = None
@@ -2683,12 +2680,7 @@ class PacketCapture:
                 payload_value = self.parse_advert(payload)
             
             if payload_type is PayloadType.ADVERT:
-                key_prefix = payload_value["public_key"][:2]
-                name = payload_value.get("name", "")
-                if name.endswith("^"):
-                    message.update(payload_value)
-                elif key_prefix not in self.opted_in_ids:
-                    self.opted_in_ids.append(key_prefix)
+                message.update(payload_value)
             else:
                 message.update(payload_value)
                 


### PR DESCRIPTION
## Summary
- always include parsed advert fields in decoded advert output
- remove the local  suppression path that never feeds any downstream behavior

## Problem
Current advert decode behavior only merges parsed advert fields into the decoded message when the advert name ends with .

Otherwise the code stores a 1-byte public-key prefix in  and does not expose the parsed advert metadata in the decoded packet output.

In practice that means many ordinary valid adverts lose useful decoded fields like:
- 
- 
- 
- 
-  / 
-  / 

## Rationale
There is no visible downstream use of  anywhere else in the repo. It is written, but never read.

So the current suppression path is not backing an active feature. It is just hiding useful advert metadata from normal capture output.

Since valid MeshCore adverts do not require a name ending with , the decoded output should preserve the parsed advert data by default.

## Behavior change
Before:
- advert metadata was only merged into the decoded message for names ending with 
- ordinary valid adverts often lost their decoded fields in output

After:
- parsed advert metadata is always merged into the decoded message
- the dead local  cache is removed

## Why this is low risk
- no on-wire parsing changes
- no MQTT connection changes
- no schema break beyond exposing already-parsed advert data consistently
- removes dead local state instead of adding new behavior branches

## Validation
- reviewed against current advert parsing flow in 
- confirmed  had no other consumers in the repo
- 

## Files
- 
