### PR TITLE
Avoid duplicate packet publishes from RAW events

### DIFF
--- a/packet_capture.py
+++ b/packet_capture.py
@@ -274,6 +274,8 @@ class PacketCapture:
         
         # Packet correlation cache
         self.rf_data_cache = {}
+        self.recent_rf_packets = {}
+        self.raw_duplicate_window = self.get_env_float('RAW_DUPLICATE_WINDOW', 2.0)
         self.packet_count = 0
         
         # Opted-in IDs for advert filtering (mirroring mctomqtt.py)
@@ -2952,6 +2954,13 @@ class PacketCapture:
                         if current_time - v['timestamp'] < timeout
                     }
                     
+                    # Remember RF-originated packets so RAW_DATA for the same reception doesn't double-publish.
+                    self.recent_rf_packets[raw_hex.upper()] = current_time
+                    self.recent_rf_packets = {
+                        k: v for k, v in self.recent_rf_packets.items()
+                        if current_time - v < self.raw_duplicate_window
+                    }
+
                     # Process the packet
                     await self.process_packet_from_rf_data(raw_hex, rf_data)
                 else:
@@ -3001,6 +3010,19 @@ class PacketCapture:
                 # Remove 0x prefix if present
                 if raw_hex.startswith('0x'):
                     raw_hex = raw_hex[2:]
+
+                raw_hex = raw_hex.upper()
+                current_time = time.time()
+                recent_rf_time = self.recent_rf_packets.get(raw_hex)
+                if recent_rf_time is not None and (current_time - recent_rf_time) < self.raw_duplicate_window:
+                    if self.debug:
+                        self.logger.debug("Skipping RAW_DATA packet already processed from RX_LOG_DATA")
+                    return
+
+                self.recent_rf_packets = {
+                    k: v for k, v in self.recent_rf_packets.items()
+                    if current_time - v < self.raw_duplicate_window
+                }
                 
                 # Find corresponding RF data
                 packet_prefix = raw_hex[:32]


### PR DESCRIPTION
## Summary
- prevent the same received packet from being published twice when both `RX_LOG_DATA` and `RAW_DATA` are emitted
- keep RF-originated packets as the authoritative publish path
- suppress only the trailing duplicate `RAW_DATA` twin within a short configurable window

## Problem
The current code subscribes to both:
- `RX_LOG_DATA`
- `RAW_DATA`

Both handlers independently process and publish packets.

That creates a duplicate-publish path when the meshcore library emits both events for the same physical packet reception:
- `RX_LOG_DATA` publishes immediately after extracting payload and RF metadata
- `RAW_DATA` later republishes the same packet again

In that case this tool can double-count packets, double-write output, and double-publish MQTT traffic for normal valid radio traffic.

## Rationale
The RF log path is the better authoritative path for normal receive processing because it includes the radio metadata (`snr`, `rssi`, payload length) that this tool already uses for formatting and output.

So this PR keeps the RF path as the primary publish path and only suppresses the later `RAW_DATA` duplicate when it clearly matches the same packet.

## Implementation
- add a small recent-packet cache keyed by normalized `raw_hex`
- record packets processed from `RX_LOG_DATA`
- when `RAW_DATA` arrives shortly after with the same payload, skip publishing it again
- keep a short cleanup window controlled by `PACKETCAPTURE_RAW_DUPLICATE_WINDOW` (default `2.0` seconds)

## Behavior change
Before:
- the same received packet could be published once from `RX_LOG_DATA` and again from `RAW_DATA`

After:
- the packet is published once from the RF path
- the duplicate `RAW_DATA` twin is skipped if it arrives within the short duplicate window
- repeated real receptions are still allowed through because only recent exact RF-originated duplicates are filtered

## Why this is low risk
- no packet parsing changes
- no MQTT schema changes
- no event subscription changes
- the duplicate suppression is narrow and time-bounded

## Validation
- reviewed against the current packet processing flow in `packet_capture.py`
- `python3 -m py_compile packet_capture.py`

## Files
- `packet_capture.py`
