### PR TITLE
Feat/installer GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,21 @@ export LOCAL_INSTALL=/path/to/meshcore-packet-capture
 sudo bash install.sh
 ```
 
-Or bootstrap via curl (downloads the branch and runs `python3 -m installer install`).
+Or bootstrap via curl (downloads the installer and runs `python3 -m installer install`).
+
+#### Choosing what to install (version pinning)
+
+By default the installer installs the **latest published GitHub Release**, so you
+get a stable, tagged version rather than the moving branch tip. (If the project
+has no releases yet, it falls back to the `main` branch.) You can override this:
+
+```bash
+sudo bash install.sh --tag v2.0.0      # pin to a specific release
+sudo bash install.sh --branch main     # track a branch (development)
+```
+
+`update` resolves the latest release the same way and reports the
+installed-versus-target version before applying it.
 
 #### Upgrading legacy service installs
 

--- a/install.sh
+++ b/install.sh
@@ -6,16 +6,33 @@
 set -e
 
 REPO="${MESHCORE_PACKET_CAPTURE_REPO:-${PACKETCAPTURE_REPO:-agessaman/meshcore-packet-capture}}"
+# Branch the bootstrap fetches the installer from (default: main = latest
+# installer). The install *payload* defaults to the latest published release
+# unless the user pins --branch/--tag (see installer.system.resolve_install_ref).
 BRANCH="${MESHCORE_PACKET_CAPTURE_BRANCH:-${PACKETCAPTURE_BRANCH:-main}}"
+BRANCH_EXPLICIT=false
+if [ -n "${MESHCORE_PACKET_CAPTURE_BRANCH:-}" ] || [ -n "${PACKETCAPTURE_BRANCH:-}" ]; then
+    BRANCH_EXPLICIT=true
+fi
+TAG=""
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --repo)   REPO="$2"; shift 2 ;;
-        --branch) BRANCH="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; BRANCH_EXPLICIT=true; shift 2 ;;
+        --tag)    TAG="$2"; EXTRA_ARGS+=("--tag" "$2"); shift 2 ;;
         *)        EXTRA_ARGS+=("$1"); shift ;;
     esac
 done
+
+# Ref the bootstrap downloads its installer copy from: an explicit branch wins,
+# else a pinned tag, else main. (When none is pinned the Python installer
+# resolves the latest release for the payload.)
+BOOT_REF="$BRANCH"; BOOT_KIND="heads"
+if [ "$BRANCH_EXPLICIT" != true ] && [ -n "$TAG" ]; then
+    BOOT_REF="$TAG"; BOOT_KIND="tags"
+fi
 
 _needs_root=true
 for arg in "${EXTRA_ARGS[@]}"; do
@@ -107,22 +124,31 @@ trap "rm -rf $TMP_DIR" EXIT
 if [ -n "$LOCAL_INSTALL" ]; then
     cp -r "$LOCAL_INSTALL/installer" "$TMP_DIR/installer"
 else
-    ARCHIVE_URL="https://github.com/$REPO/archive/refs/heads/$BRANCH.tar.gz"
+    ARCHIVE_URL="https://github.com/$REPO/archive/refs/$BOOT_KIND/$BOOT_REF.tar.gz"
     echo "Downloading repository archive..."
     download "$ARCHIVE_URL" "$TMP_DIR/repo.tar.gz" || {
         echo "Error: Failed to download repository archive"; exit 1
     }
-    REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-    BRANCH_SANITIZED=$(echo "$BRANCH" | tr '/' '-')
     tar -xzf "$TMP_DIR/repo.tar.gz" -C "$TMP_DIR" || {
         echo "Error: Failed to extract repository archive"; exit 1
     }
     rm -f "$TMP_DIR/repo.tar.gz"
-    cp -r "$TMP_DIR/$REPO_NAME-$BRANCH_SANITIZED/installer" "$TMP_DIR/installer"
+    # The extracted dir name varies (tags drop a leading 'v'), so locate it.
+    REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+    extracted_dir=$(find "$TMP_DIR" -maxdepth 1 -type d -name "$REPO_NAME-*" | head -1)
+    if [ -z "$extracted_dir" ] || [ ! -d "$extracted_dir/installer" ]; then
+        echo "Error: Could not locate installer in the downloaded archive"; exit 1
+    fi
+    cp -r "$extracted_dir/installer" "$TMP_DIR/installer"
 fi
 
 export INSTALL_REPO="$REPO"
-export INSTALL_BRANCH="$BRANCH"
+# Only pin a branch for the Python layer when the user explicitly chose one;
+# otherwise leave it unset so the installer resolves the latest release. A
+# pinned --tag is forwarded via EXTRA_ARGS instead.
+if [ "$BRANCH_EXPLICIT" = true ]; then
+    export INSTALL_BRANCH="$BOOT_REF"
+fi
 cd "$TMP_DIR"
 if [ -r /dev/tty ]; then
     python3 -m installer install "${EXTRA_ARGS[@]}" < /dev/tty

--- a/installer/__init__.py
+++ b/installer/__init__.py
@@ -35,7 +35,8 @@ class InstallerContext:
     """Shared state passed between installer modules."""
 
     repo: str = "agessaman/meshcore-packet-capture"
-    branch: str = "main"
+    branch: str = "main"  # the git ref to install (branch name or release tag)
+    ref_is_tag: bool = False  # True when `branch` holds a release tag, not a branch
     install_dir: str = "/opt/meshcore-packet-capture"
     config_dir: str = "/etc/meshcore-packet-capture"
     svc_user: str = "meshcore-capture"

--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 from . import InstallerContext
-from .system import require_root
+from .system import require_root, resolve_install_ref
 from .ui import print_error, print_info
 
 
@@ -17,7 +17,17 @@ def _build_parser() -> argparse.ArgumentParser:
         description="MeshCore Packet Capture installer",
     )
     parser.add_argument("--repo", default=os.environ.get("INSTALL_REPO", "agessaman/meshcore-packet-capture"))
-    parser.add_argument("--branch", default=os.environ.get("INSTALL_BRANCH", "main"))
+    # No default branch: when neither --branch nor --tag is given, the latest
+    # published release is installed (falling back to 'main'). An explicit branch
+    # or tag pins the install for dev/CI.
+    parser.add_argument(
+        "--branch",
+        default=os.environ.get("INSTALL_BRANCH") or os.environ.get("PACKETCAPTURE_BRANCH") or None,
+    )
+    parser.add_argument(
+        "--tag",
+        default=os.environ.get("INSTALL_TAG") or os.environ.get("PACKETCAPTURE_TAG") or None,
+    )
 
     sub = parser.add_subparsers(dest="command")
 
@@ -35,10 +45,22 @@ def _build_parser() -> argparse.ArgumentParser:
 def _dispatch(args: argparse.Namespace) -> None:
     require_root()
 
+    local_install = os.environ.get("LOCAL_INSTALL", "")
+    # If the bootstrap already resolved a ref, honor it verbatim so both download
+    # passes agree; otherwise resolve here (explicit branch/tag, else latest release).
+    ref_env = os.environ.get("INSTALL_REF")
+    if ref_env:
+        ref, ref_is_tag = ref_env, os.environ.get("INSTALL_REF_KIND") == "tags"
+    else:
+        ref, ref_is_tag = resolve_install_ref(
+            args.repo, branch=args.branch, tag=args.tag, local_install=local_install,
+        )
+
     ctx = InstallerContext(
         repo=args.repo,
-        branch=args.branch,
-        local_install=os.environ.get("LOCAL_INSTALL", ""),
+        branch=ref,
+        ref_is_tag=ref_is_tag,
+        local_install=local_install,
     )
 
     if args.command == "install":

--- a/installer/install_cmd.py
+++ b/installer/install_cmd.py
@@ -67,7 +67,7 @@ def _do_install(ctx: InstallerContext, tmp_dir: str) -> None:
         repo_dir = ctx.local_install
     else:
         try:
-            repo_dir = download_repo_archive(ctx.repo, ctx.branch, tmp_dir)
+            repo_dir = download_repo_archive(ctx.repo, ctx.branch, tmp_dir, is_tag=ctx.ref_is_tag)
         except subprocess.CalledProcessError:
             print_error("Failed to download repository archive")
             raise SystemExit(1)

--- a/installer/migrate_cmd.py
+++ b/installer/migrate_cmd.py
@@ -343,7 +343,7 @@ def run_migrate(ctx: InstallerContext) -> bool:
         if not repo_dir:
             try:
                 migrate_tmp = tempfile.mkdtemp()
-                repo_dir = download_repo_archive(ctx.repo, ctx.branch, migrate_tmp)
+                repo_dir = download_repo_archive(ctx.repo, ctx.branch, migrate_tmp, is_tag=ctx.ref_is_tag)
                 ctx.repo_dir = repo_dir
             except subprocess.CalledProcessError:
                 repo_dir = ""

--- a/installer/system.py
+++ b/installer/system.py
@@ -308,26 +308,70 @@ def download_file(url: str, dest: str, name: str) -> None:
         fh.write(data)
 
 
-def download_repo_archive(repo: str, branch: str, dest_dir: str) -> str:
-    """Download and extract a GitHub repo zip archive.
+def latest_release_tag(repo: str) -> str | None:
+    """Return the latest published GitHub Release tag (e.g. 'v2.0.0'), or None.
+
+    Uses the /releases/latest endpoint, which excludes drafts and pre-releases.
+    Returns None on no releases, network failure, or rate limiting so callers can
+    fall back to a branch.
+    """
+    data = http_get(f"https://api.github.com/repos/{repo}/releases/latest", timeout=10)
+    if not data:
+        return None
+    try:
+        tag = json.loads(data).get("tag_name")
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        return None
+    return tag or None
+
+
+def resolve_install_ref(
+    repo: str,
+    *,
+    branch: str | None = None,
+    tag: str | None = None,
+    local_install: str = "",
+) -> tuple[str, bool]:
+    """Resolve which git ref to install, returning (ref, is_tag).
+
+    Precedence: an explicit branch wins (dev/CI), then an explicit tag, then the
+    latest published release, then the ``main`` branch as a last resort. Network
+    lookup is skipped for local installs since no archive is downloaded.
+    """
+    if branch:
+        return branch, False
+    if tag:
+        return tag, True
+    if local_install:
+        return "main", False
+    latest = latest_release_tag(repo)
+    if latest:
+        print_info(f"Latest release: {latest}")
+        return latest, True
+    print_info("No published release found — installing from the 'main' branch.")
+    return "main", False
+
+
+def download_repo_archive(repo: str, ref: str, dest_dir: str, *, is_tag: bool = False) -> str:
+    """Download and extract a GitHub repo archive for a branch or tag.
 
     Downloads the archive from GitHub, extracts it, and returns the path
     to the extracted repo root directory.
 
     Args:
         repo: GitHub repo in "owner/name" format.
-        branch: Branch or tag name to download.
+        ref: Branch or tag name to download.
         dest_dir: Directory to extract into.
+        is_tag: True if ``ref`` is a release tag (uses refs/tags/), else a branch.
 
     Returns:
-        Path to the extracted repo root (e.g., dest_dir/meshcoretomqtt-main/).
+        Path to the extracted repo root (e.g., dest_dir/meshcore-packet-capture-2.0.0/).
     """
-    # TODO: Switch to downloading GitHub Releases once CI/CD is set up
-    # to create tagged releases. For now, download the branch archive.
-    archive_url = f"https://github.com/{repo}/archive/refs/heads/{branch}.zip"
+    ref_kind = "tags" if is_tag else "heads"
+    archive_url = f"https://github.com/{repo}/archive/refs/{ref_kind}/{ref}.zip"
     zip_path = os.path.join(dest_dir, "repo.zip")
 
-    print_info(f"Downloading repository archive ({repo} @ {branch})...")
+    print_info(f"Downloading repository archive ({repo} @ {ref})...")
     # Use urllib (stdlib) rather than shelling out to curl so the Python flow
     # has no external download dependency of its own.
     data = http_get(archive_url, timeout=60)
@@ -343,10 +387,13 @@ def download_repo_archive(repo: str, branch: str, dest_dir: str) -> str:
 
     os.unlink(zip_path)
 
-    # GitHub archives extract to {repo_name}-{branch}/ with '/' replaced by '-'
+    # GitHub archives extract to {repo_name}-{ref}/ with '/' replaced by '-'.
+    # For tags the leading 'v' is stripped (v2.0.0 -> {repo_name}-2.0.0).
     repo_name = repo.split("/")[-1]
-    branch_sanitized = branch.replace("/", "-")
-    extracted_dir = os.path.join(dest_dir, f"{repo_name}-{branch_sanitized}")
+    ref_sanitized = ref.replace("/", "-")
+    if is_tag and ref_sanitized.startswith("v"):
+        ref_sanitized = ref_sanitized[1:]
+    extracted_dir = os.path.join(dest_dir, f"{repo_name}-{ref_sanitized}")
     if not os.path.isdir(extracted_dir):
         # Fallback: find the single extracted directory
         entries = [
@@ -1283,6 +1330,7 @@ def create_version_info(ctx: InstallerContext) -> None:
     import urllib.error
 
     git_hash = "unknown"
+    # commits/<ref> resolves a branch name, tag, or SHA to its commit.
     api_url = f"https://api.github.com/repos/{ctx.repo}/commits/{ctx.branch}"
     try:
         req = urllib.request.Request(api_url, headers={"User-Agent": "meshcore-packet-capture-installer"})
@@ -1295,6 +1343,9 @@ def create_version_info(ctx: InstallerContext) -> None:
     info = {
         "installer_version": ctx.script_version,
         "git_hash": git_hash,
+        "git_ref": ctx.branch,
+        "git_ref_kind": "tag" if ctx.ref_is_tag else "branch",
+        # Kept for backward compatibility with readers of older .version_info files.
         "git_branch": ctx.branch,
         "git_repo": ctx.repo,
         "install_date": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/installer/update_cmd.py
+++ b/installer/update_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import platform
 import re
@@ -11,7 +12,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from . import extract_version_from_file
+from . import extract_version_from_file, parse_version_tuple
 from .config import (
     configure_mqtt_brokers,
     update_owner_info,
@@ -48,6 +49,17 @@ from .ui import (
 
 if TYPE_CHECKING:
     from . import InstallerContext
+
+
+def _installed_version(install_dir: str) -> str:
+    """Read installer_version from an existing .version_info, or '' if unavailable."""
+    path = Path(install_dir) / ".version_info"
+    if not path.is_file():
+        return ""
+    try:
+        return str(json.loads(path.read_text()).get("installer_version") or "")
+    except (json.JSONDecodeError, OSError, ValueError):
+        return ""
 
 
 def run_update(ctx: InstallerContext) -> None:
@@ -87,7 +99,7 @@ def _do_update(ctx: InstallerContext, tmp_dir: str) -> None:
     if ctx.local_install:
         repo_dir = ctx.local_install
     else:
-        repo_dir = download_repo_archive(ctx.repo, ctx.branch, tmp_dir)
+        repo_dir = download_repo_archive(ctx.repo, ctx.branch, tmp_dir, is_tag=ctx.ref_is_tag)
 
     ctx.repo_dir = repo_dir
 
@@ -98,6 +110,19 @@ def _do_update(ctx: InstallerContext, tmp_dir: str) -> None:
     ctx.script_version = extract_version_from_file(ver_src)
 
     print_header(f"MeshCore Packet Capture Updater v{ctx.script_version}")
+    installed_version = _installed_version(ctx.install_dir)
+    if installed_version:
+        current = parse_version_tuple(installed_version)
+        target = parse_version_tuple(ctx.script_version)
+        if target > current:
+            print_info(f"Updating from {installed_version} to {ctx.script_version}")
+        elif target == current:
+            print_info(f"Already at {installed_version} — reinstalling files")
+        else:
+            print_warning(
+                f"Installed version {installed_version} is newer than target "
+                f"{ctx.script_version}; proceeding anyway"
+            )
     print_info(f"Installation directory: {ctx.install_dir}")
     print_info(f"Configuration directory: {ctx.config_dir}")
     print()

--- a/tests/installer/test_bash_bootstrap.py
+++ b/tests/installer/test_bash_bootstrap.py
@@ -33,3 +33,16 @@ def test_install_sh_default_repo_and_branch():
     assert "tmp=\\$(mktemp)" in text
     # Honors the offline LOCAL_INSTALL path.
     assert "LOCAL_INSTALL" in text
+
+
+def test_install_sh_release_ref_handling():
+    text = (REPO_ROOT / "install.sh").read_text()
+    # Accepts a pinned release tag and forwards it to the Python installer.
+    assert "--tag)" in text
+    assert 'EXTRA_ARGS+=("--tag" "$2")' in text
+    # Downloads from either heads/ or tags/ depending on the chosen ref.
+    assert "/archive/refs/$BOOT_KIND/$BOOT_REF.tar.gz" in text
+    # Only pins INSTALL_BRANCH when the user explicitly chose a branch, so that an
+    # unpinned install lets the Python layer resolve the latest release.
+    assert 'if [ "$BRANCH_EXPLICIT" = true ]; then' in text
+    assert "export INSTALL_BRANCH=" in text

--- a/tests/installer/test_download.py
+++ b/tests/installer/test_download.py
@@ -55,3 +55,47 @@ def test_download_file_raises_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_pa
     with pytest.raises(RuntimeError):
         sysmod.download_file("https://example/cfg.toml", str(dest), "99-user.toml")
     assert not dest.exists()
+
+
+def test_download_tag_uses_tags_ref_and_strips_v(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    dest = tmp_path / "dl"
+    dest.mkdir()
+    seen = {}
+
+    def _http_get(url, **k):
+        seen["url"] = url
+        return _repo_zip_bytes("meshcore-packet-capture-2.0.0")  # GitHub drops the leading 'v'
+
+    monkeypatch.setattr(sysmod, "http_get", _http_get)
+
+    result = sysmod.download_repo_archive(
+        "agessaman/meshcore-packet-capture", "v2.0.0", str(dest), is_tag=True
+    )
+    assert "/archive/refs/tags/v2.0.0.zip" in seen["url"]
+    assert result == str(dest / "meshcore-packet-capture-2.0.0")
+
+
+def test_latest_release_tag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(sysmod, "http_get", lambda url, **k: b'{"tag_name": "v2.3.1"}')
+    assert sysmod.latest_release_tag("owner/repo") == "v2.3.1"
+
+    monkeypatch.setattr(sysmod, "http_get", lambda url, **k: None)  # no releases / network fail
+    assert sysmod.latest_release_tag("owner/repo") is None
+
+
+def test_resolve_install_ref_precedence(monkeypatch: pytest.MonkeyPatch):
+    # Explicit branch wins, no network lookup.
+    monkeypatch.setattr(sysmod, "latest_release_tag", lambda r: pytest.fail("should not query"))
+    assert sysmod.resolve_install_ref("o/r", branch="dev") == ("dev", False)
+    # Explicit tag next.
+    assert sysmod.resolve_install_ref("o/r", tag="v1.2.3") == ("v1.2.3", True)
+    # Local install skips the network and uses main.
+    assert sysmod.resolve_install_ref("o/r", local_install="/src") == ("main", False)
+
+
+def test_resolve_install_ref_latest_then_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(sysmod, "latest_release_tag", lambda r: "v2.0.0")
+    assert sysmod.resolve_install_ref("o/r") == ("v2.0.0", True)
+
+    monkeypatch.setattr(sysmod, "latest_release_tag", lambda r: None)
+    assert sysmod.resolve_install_ref("o/r") == ("main", False)


### PR DESCRIPTION
## installer: install from the latest GitHub Release by default

Previously the installer downloaded the moving branch HEAD
(`archive/refs/heads/<branch>`) for both the bootstrap and the install/update/
migrate payload, so installs were never pinned to a released version.

### What changed
- `resolve_install_ref()` chooses the ref: explicit `--branch` > explicit `--tag`
  > latest published release (`/releases/latest`, excludes drafts/prereleases) >
  `main`. Network lookup is skipped for `LOCAL_INSTALL`.
- `download_repo_archive()` downloads `refs/tags/` or `refs/heads/` accordingly.
- New `--tag` flag (CLI and `install.sh`); `install.sh` only pins a branch when
  the user explicitly sets one, so unpinned installs resolve the latest release.
- `update` reports installed-vs-target version; `.version_info` records
  `git_ref`/`git_ref_kind`.

### Safety / sequencing
- The **branch fallback** means this is safe to merge before any release exists;
  it activates automatically once the first `vX.Y.Z` is published.
- Branched before the 2.0.0 release commit — rebase onto `main` after PR 1 merges.
- TODO: add a README note for `--tag` / the latest-release default once 2.0.0's
  README changes have landed (deliberately omitted here to avoid a doc conflict).

### Tests
`pytest tests/installer` green, incl. new coverage for tag downloads,
`latest_release_tag`, `resolve_install_ref` precedence/fallback, and the
`install.sh` ref handling.