### PR TITLE
fix(installer): forward pinned tag before install subcommand

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,13 +15,14 @@ if [ -n "${MESHCORE_PACKET_CAPTURE_BRANCH:-}" ] || [ -n "${PACKETCAPTURE_BRANCH:
     BRANCH_EXPLICIT=true
 fi
 TAG=""
+TAG_ARGS=()
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --repo)   REPO="$2"; shift 2 ;;
         --branch) BRANCH="$2"; BRANCH_EXPLICIT=true; shift 2 ;;
-        --tag)    TAG="$2"; EXTRA_ARGS+=("--tag" "$2"); shift 2 ;;
+        --tag)    TAG="$2"; TAG_ARGS=("--tag" "$2"); shift 2 ;;
         *)        EXTRA_ARGS+=("$1"); shift ;;
     esac
 done
@@ -145,13 +146,14 @@ fi
 export INSTALL_REPO="$REPO"
 # Only pin a branch for the Python layer when the user explicitly chose one;
 # otherwise leave it unset so the installer resolves the latest release. A
-# pinned --tag is forwarded via EXTRA_ARGS instead.
+# pinned --tag is forwarded via TAG_ARGS and placed before the install
+# subcommand so argparse accepts it as a global option.
 if [ "$BRANCH_EXPLICIT" = true ]; then
     export INSTALL_BRANCH="$BOOT_REF"
 fi
 cd "$TMP_DIR"
 if [ -r /dev/tty ]; then
-    python3 -m installer install "${EXTRA_ARGS[@]}" < /dev/tty
+    python3 -m installer "${TAG_ARGS[@]}" install "${EXTRA_ARGS[@]}" < /dev/tty
 else
-    python3 -m installer install "${EXTRA_ARGS[@]}"
+    python3 -m installer "${TAG_ARGS[@]}" install "${EXTRA_ARGS[@]}"
 fi

--- a/tests/installer/test_bash_bootstrap.py
+++ b/tests/installer/test_bash_bootstrap.py
@@ -39,10 +39,17 @@ def test_install_sh_release_ref_handling():
     text = (REPO_ROOT / "install.sh").read_text()
     # Accepts a pinned release tag and forwards it to the Python installer.
     assert "--tag)" in text
-    assert 'EXTRA_ARGS+=("--tag" "$2")' in text
+    assert 'TAG_ARGS=("--tag" "$2")' in text
     # Downloads from either heads/ or tags/ depending on the chosen ref.
     assert "/archive/refs/$BOOT_KIND/$BOOT_REF.tar.gz" in text
     # Only pins INSTALL_BRANCH when the user explicitly chose a branch, so that an
     # unpinned install lets the Python layer resolve the latest release.
     assert 'if [ "$BRANCH_EXPLICIT" = true ]; then' in text
     assert "export INSTALL_BRANCH=" in text
+
+
+def test_install_sh_tag_placed_before_install_subcommand():
+    """Regression test for #38: --tag must be a global argparse option placed
+    before the install subcommand, not after."""
+    text = (REPO_ROOT / "install.sh").read_text()
+    assert 'python3 -m installer "${TAG_ARGS[@]}" install "${EXTRA_ARGS[@]}"' in text


### PR DESCRIPTION
## Summary

Moves the bootstrap `--tag` option before the `install` subcommand, where the Python CLI accepts global options. Other install-subcommand options remain after `install`.

Fixes #38.

## Validation

- `bash -n install.sh`
- `python3 -m pytest tests/installer/test_bash_bootstrap.py -q` → 5 passed
- Baseline regression gate: the updated bootstrap test fails against unmodified `main`
- Full development suite: 216 passed
- `gitleaks` found no leaks

I do not run continuously; responses are typically within 24–48 hours.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
