### PR TITLE
Publish a periodic neighbors snapshot, and serialise device commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/agessaman/meshcore-packet-ca
 ## Requirements
 
 - Python 3.11+ (installer and recommended runtime)
-- `meshcore` package (official MeshCore Python library) version 2.2.31 or later (required for multi-byte path support and stats)
+- `meshcore` package (official MeshCore Python library) version 2.3.8 or later (required for multi-byte path support, stats, serialised BLE writes, and the zero-hop anonymous requests the neighbors snapshot depends on)
 - `paho-mqtt` package (for MQTT functionality)
 
 **Note**: For Docker deployment, this application is best deployed on Linux systems due to Bluetooth Low Energy (BLE) and serial device access requirements. While Docker containers can run on macOS and Windows, BLE functionality may be limited or require additional configuration.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ status  = "meshcore/{IATA}/{PUBLIC_KEY}/status"
 ```
 These flatten to `PACKETCAPTURE_MQTT<n>_TOPIC_<NAME>` (per broker) and
 `PACKETCAPTURE_TOPIC_<NAME>` (global fallback) — supported names: `STATUS`,
-`PACKETS`, `DECODED`, `DEBUG`, `RAW`.
+`PACKETS`, `DECODED`, `DEBUG`, `RAW`, `NEIGHBORS`.
 
 #### Authentication Methods
 
@@ -625,11 +625,95 @@ Default topic templates (from the shipped `config.toml`):
 - `meshcore/{IATA}/{PUBLIC_KEY}/status`: Device online/offline status (plus optional stats)
 - `meshcore/{IATA}/{PUBLIC_KEY}/packets`: Full packet data
 - `meshcore/{IATA}/{PUBLIC_KEY}/raw`: Raw packet data (commented out by default; enable it for e.g. map.w0z.is)
+- `meshcore/{IATA}/{PUBLIC_KEY}/neighbors`: Periodic neighbor snapshot (off by default; see [Neighbors Publishing](#neighbors-publishing))
 
 These are configurable globally or per broker — see [Topic Templates](#topic-templates)
 and [Per-Broker Topic Overrides](#per-broker-topic-overrides). The classic flat form
 (`meshcore/status`, `meshcore/packets`, `meshcore/raw`) still works if you set the
 topics explicitly.
+
+## Neighbors Publishing
+
+A port of the observer firmware's neighbors feature. On a long interval the tool asks
+which repeaters it can hear directly, then asks each one for its region scopes, and
+publishes the result to the `neighbors` topic. **Off by default.**
+
+Enable it per broker, since not every broker accepts this topic:
+
+```toml
+[[broker]]
+name = "analyzer"
+enabled = true
+server = "mqtt.example.com"
+neighbors = true          # opt this broker in
+
+[capture]
+neighbors_interval_hours = 24   # clamped to 12-336
+```
+
+The topic needs an IATA code (or an explicit `[broker.topics] neighbors` template) —
+there is no flat `meshcore/neighbors` fallback, matching the firmware, which only routes
+this topic in MeshCore form. Payloads are published non-retained.
+
+Each cycle runs two stages: a zero-hop node-discover collecting responses for
+`neighbors_discover_window` seconds, then one scope request per neighbor. Those requests
+go out **one at a time** — issuing them together makes the replies collide on air. Each
+wait defaults to the device's own airtime estimate (`neighbors_scope_timeout = 0`), with
+`neighbors_scope_gap` seconds between requests and `neighbors_cycle_timeout` bounding the
+whole pass. Neighbors are queried most-recently-heard first, so a truncated cycle still
+covers the most useful ones. See `config.toml.example` for every knob.
+
+```json
+{
+  "timestamp": "2024-01-01T12:00:00.000000+00:00",
+  "origin": "MeshCore-HOWL",
+  "origin_id": "A1B2C3D4E5F67890...",
+  "total_neighbors": 6,
+  "queried_neighbors": 6,
+  "truncated": false,
+  "self": { "scopes": "DEN,APRS" },
+  "neighbors": [
+    {
+      "pubkey": "0011223344556677...",
+      "snr": 9.75,
+      "heard_secs_ago": 42,
+      "scopes": "DEN,APRS",
+      "status": "responded"
+    }
+  ]
+}
+```
+
+### Triggering a cycle manually
+
+The minimum interval is 12 hours, so for testing use the one-shot trigger — the
+equivalent of the firmware's `discover.neighbors` / scope pass:
+
+```bash
+# Run one cycle now, then keep capturing normally
+python -m meshcore_packet_capture --neighbors-now --verbose
+
+# Run one cycle and exit
+python -m meshcore_packet_capture --neighbors-now --neighbors-exit --verbose
+```
+
+It runs after the device and brokers connect, before the scheduler starts, and takes
+roughly `neighbors_discover_window` seconds plus a few seconds per neighbor. Add `--debug`
+to see each discover response and scope reply. A cycle also runs automatically on first
+start, since no previous publish is recorded.
+
+`total_neighbors` is how many were discovered, `queried_neighbors` how many were
+actually asked for scopes, and `truncated` is true when either the `neighbors_max`
+cap or the payload budget dropped some.
+
+`status` is `responded`, `timeout`, or `send_failed` per neighbor. Entries are ordered
+most- to least-useful (most recently heard, then stronger SNR) and the tail is dropped if
+the payload would exceed 10 KB, matching the firmware's buffer.
+
+Two differences from the firmware worth knowing: `heard_secs_ago` is measured within the
+current cycle (this tool keeps no long-lived neighbor table), and `self.scopes` comes from
+the radio's default flood scope name, since a companion radio has no region map — set
+`neighbors_self_scopes` to declare it explicitly.
 
 ## Troubleshooting
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -73,6 +73,23 @@ rf_data_timeout = 15.0
 # decode_channel_keys = "name=hexOrBase64,other=..."  # Custom channel keys (16-byte hex or base64)
 # decode_include_public = true      # Include the well-known default "Public" channel key
 
+# --- Neighbors publishing (zero-hop neighbor table + each neighbor's region scopes) ---
+# Off by default. Opt in per broker with `neighbors = true` in its [[broker]] block; the
+# cycle only runs when at least one enabled broker has done so. Published non-retained to
+# the `neighbors` topic, which needs an IATA (or an explicit [broker.topics] neighbors).
+# Each cycle: one zero-hop node-discover, then one scope request per neighbor, issued one
+# at a time -- firing them together collides the responses.
+# neighbors_interval_hours = 24     # clamped to 12-336 (matches the observer firmware)
+# neighbors_discover_window = 60    # seconds spent collecting discover responses
+# neighbors_command_timeout = 20    # cap on the discover request itself; a stalled
+#                                   # BLE/serial write can otherwise block indefinitely
+# neighbors_scope_timeout = 0       # per-request wait; 0 = use the device's own estimate
+# neighbors_scope_min_timeout = 8   # floor under the device-suggested timeout
+# neighbors_scope_gap = 2.0         # settle delay between scope requests
+# neighbors_cycle_timeout = 600     # overall budget for the scope pass
+# neighbors_max = 32                # cap on neighbors queried per cycle (most useful first)
+# neighbors_self_scopes = ""        # override for this node's own "self.scopes" value
+
 # --- Packet log rotation (only applies when an output file is given with --output) ---
 # log_rotation = "off"              # off | size | time
 # log_max_bytes = "50MB"            # size mode threshold (accepts 50MB, 10M, ...)
@@ -91,6 +108,7 @@ rf_data_timeout = 15.0
 # qos = 0
 # retain = true
 # include_decoded = true   # Publish the "decoded" object to this broker (default: capture.include_decoded, off)
+# neighbors = false        # Publish the neighbors snapshot to this broker (default off)
 #
 # [broker.tls]
 # enabled = false
@@ -109,6 +127,6 @@ rf_data_timeout = 15.0
 # email = "you@example.com"          # Optional; overrides capture.owner_email for this broker
 #
 # Optional per-broker topic overrides (take precedence over the global [topics];
-# unset keys fall back to [topics]). Keys: status, packets, decoded, debug, raw.
+# unset keys fall back to [topics]). Keys: status, packets, decoded, debug, raw, neighbors.
 # [broker.topics]
 # packets = "custom/{IATA}/{PUBLIC_KEY}/packets"

--- a/installer/system.py
+++ b/installer/system.py
@@ -1302,7 +1302,7 @@ def create_venv(install_dir: str, svc_user: str) -> None:
     else:
         run_cmd([
             f"{venv_dir}/bin/pip", "install", "--quiet",
-            "meshcore>=2.2.31", "paho-mqtt", "bleak", "pyserial-asyncio", "pexpect", "pynacl",
+            "meshcore>=2.3.8", "paho-mqtt", "bleak", "pyserial-asyncio", "pexpect", "pynacl",
         ])
         print_success("Python dependencies installed (meshcore stack)")
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -5,19 +5,19 @@
       # Note: If meshcore is available in nixpkgs, you can override this
       meshcorePackage = pkgs.python3Packages.buildPythonPackage rec {
         pname = "meshcore";
-        version = "2.2.31";
+        version = "2.3.8";
         format = "pyproject";
-        
+
         src = pkgs.python3Packages.fetchPypi {
           inherit pname version;
-          sha256 = "sha256-Z0FkdOY9Kv/y2fPXyH266CaWIWLeHwgC+yqSRLZxog8=";
+          sha256 = "sha256-ItV9u1kYavbtIwP9FJY1AimJpPjchnxymm8KvDStOqs=";
         };
         
         nativeBuildInputs = with pkgs.python3Packages; [
           hatchling
         ];
         
-        # meshcore 2.2.31's wheel requires these at runtime; nixpkgs' Python deps
+        # meshcore's wheel requires these at runtime; nixpkgs' Python deps
         # check (pythonRuntimeDepsCheck) fails the build if they're not provided.
         propagatedBuildInputs = with pkgs.python3Packages; [
           bleak

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "MIT" }
 dynamic = ["version"]
 dependencies = [
     "paho-mqtt>=1.6.0",
-    "meshcore>=2.2.31",
+    "meshcore>=2.3.8",
     "bleak>=0.21.0",
     "pyserial-asyncio>=0.6",
     "pycayennelpp>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,13 @@
 # Core dependencies for MeshCore packet capture
 paho-mqtt>=1.6.0
 
-# MeshCore package - multi-byte path support requires 2.2.31+
-meshcore>=2.2.31
+# MeshCore package - 2.3.8+ is required, not merely preferred:
+#   - send_anon_req() falls back to a zero-hop reply path for an unknown
+#     destination, which is what lets neighbors.py ask a freshly discovered
+#     repeater for its scopes. Earlier releases refuse the request client-side.
+#   - ble_cx serialises write_gatt_char() and bounds it. Two overlapping BLE
+#     writes drop the link outright ("BLE write failed: 19").
+meshcore>=2.3.8
 
 # MeshCore package dependencies (installed automatically with meshcore)
 bleak>=0.21.0

--- a/src/meshcore_packet_capture/config_loader.py
+++ b/src/meshcore_packet_capture/config_loader.py
@@ -138,6 +138,8 @@ def _broker_to_env_slot(broker: dict[str, Any], slot: int) -> dict[str, str]:
         out[prefix + "IATA"] = str(broker["iata"])
     if "include_decoded" in broker:
         out[prefix + "INCLUDE_DECODED"] = _bool_str(broker["include_decoded"])
+    if "neighbors" in broker:
+        out[prefix + "NEIGHBORS"] = _bool_str(broker["neighbors"])
 
     tls = broker.get("tls") or {}
     if tls:
@@ -271,6 +273,16 @@ def flatten_config_to_env_dict(config: dict[str, Any]) -> dict[str, str]:
         "decode_hashtag_channels": "DECODE_HASHTAG_CHANNELS",
         "decode_channel_keys": "DECODE_CHANNEL_KEYS",
         "decode_include_public": "DECODE_INCLUDE_PUBLIC",
+        # Neighbors publishing (opt in per broker with [[broker]] neighbors = true)
+        "neighbors_interval_hours": "NEIGHBORS_INTERVAL_HOURS",
+        "neighbors_discover_window": "NEIGHBORS_DISCOVER_WINDOW",
+        "neighbors_command_timeout": "NEIGHBORS_COMMAND_TIMEOUT",
+        "neighbors_scope_timeout": "NEIGHBORS_SCOPE_TIMEOUT",
+        "neighbors_scope_min_timeout": "NEIGHBORS_SCOPE_MIN_TIMEOUT",
+        "neighbors_scope_gap": "NEIGHBORS_SCOPE_GAP",
+        "neighbors_cycle_timeout": "NEIGHBORS_CYCLE_TIMEOUT",
+        "neighbors_max": "NEIGHBORS_MAX",
+        "neighbors_self_scopes": "NEIGHBORS_SELF_SCOPES",
         # Packet log rotation
         "log_rotation": "LOG_ROTATION",
         "log_max_bytes": "LOG_MAX_BYTES",

--- a/src/meshcore_packet_capture/neighbors.py
+++ b/src/meshcore_packet_capture/neighbors.py
@@ -10,7 +10,12 @@ examples/simple_repeater/MyMesh.cpp). Two stages per cycle:
    scope names.
 
 Both requests are issued through meshcore_py (``send_node_discover_req`` and
-``req_regions_sync``); nothing here re-encodes packets.
+``req_regions_sync``); nothing here re-encodes packets. Stage 2 requires
+meshcore >= 2.3.8, where ``send_anon_req`` requests a zero-hop reply path for a
+destination that is not a known contact -- which a just-discovered neighbor
+never is. Earlier releases refused such a request client-side, and this module
+used to work around that by injecting a synthetic contact into the library's
+cache for the duration of each query.
 
 Stage 2 is deliberately paced. The firmware originally fired every request at
 once and the responses collided, so it moved to one request in flight at a time
@@ -26,7 +31,7 @@ import asyncio
 import json
 import random
 import time
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -46,10 +51,11 @@ NEIGHBORS_JSON_BUDGET = 10240
 async def _maybe_lock(lock):
     """Hold ``lock`` if one was supplied, otherwise do nothing.
 
-    Device commands must not overlap: two concurrent writes to the BLE RX
-    characteristic drop the link. The caller owns the lock so neighbors requests
-    serialise against the app's other device traffic (status publishes, stats,
-    health checks), not just against each other.
+    Device commands must not overlap: a command is a write plus a wait for its
+    reply, and meshcore_py serialises neither, so concurrent commands awaiting
+    the same event type can take each other's response. The caller owns the lock
+    so neighbors requests serialise against the app's other device traffic
+    (status publishes, stats, health checks), not just against each other.
     """
     if lock is None:
         yield
@@ -295,63 +301,6 @@ async def discover_neighbors(
     return sort_entries(list(collected.values()))
 
 
-def _zero_hop_contact(pubkey: str) -> dict[str, Any]:
-    """A synthetic zero-hop contact entry for the library's contact cache.
-
-    ``send_anon_req`` refuses to send unless the target resolves in the client
-    cache, and uses the entry only to build the reply-path bytes. The companion
-    firmware needs no such contact — CMD_SEND_ANON_REQ synthesises a transient
-    one (out_path_len = 0, hidden from CMD_GET_CONTACTS, never persisted; see
-    companion_radio/MyMesh.cpp and BaseChatMesh::allocateContactSlot).
-
-    out_path_len = 0 keeps the library off its out_path_len == -1 branch, so it
-    issues no change_contact_path/reset_path writes to the device, and the
-    request carries an empty reply path -- the zero-hop direct probe the
-    firmware feature sends.
-    """
-    return {
-        "public_key": pubkey,
-        "out_path_len": 0,
-        "out_path": "",
-        "adv_name": "",
-        "type": 0,
-    }
-
-
-@contextmanager
-def zero_hop_contact_override(meshcore, pubkey: str, logger):
-    """Temporarily force ``pubkey`` to resolve as a zero-hop contact.
-
-    Yields True when the override is in place, False when the contact cache is
-    unavailable — callers must treat False as "no request can be sent", because
-    ``req_regions_sync`` would report ``contact_not_found`` and, since it maps
-    every failure to ``None``, that would be indistinguishable from a neighbor
-    that simply didn't answer.
-
-    The cache is keyed by public_key (see MeshCore._update_contacts), so writing
-    under the same key overrides any real contact - including one carrying a
-    stale multi-hop path that would otherwise route the probe the long way - and
-    restores it exactly on exit.
-    """
-    # Public property; returns the same dict object the library mutates.
-    contacts = getattr(meshcore, "contacts", None)
-    if not isinstance(contacts, dict):
-        logger.warning("Neighbors: contact cache unavailable, cannot issue scope requests")
-        yield False
-        return
-
-    had_original = pubkey in contacts
-    original = contacts.get(pubkey)
-    contacts[pubkey] = _zero_hop_contact(pubkey)
-    try:
-        yield True
-    finally:
-        if had_original:
-            contacts[pubkey] = original
-        else:
-            contacts.pop(pubkey, None)
-
-
 async def collect_scopes(
     meshcore,
     entries: list[NeighborEntry],
@@ -367,6 +316,14 @@ async def collect_scopes(
     budget runs out the most useful neighbors have been covered. Anything not
     reached keeps its initial ``timeout`` status, matching the firmware's
     fallback.
+
+    The probe is zero-hop, matching the firmware. That falls out of
+    ``send_anon_req`` (meshcore >= 2.3.8) requesting a zero-hop direct reply path
+    whenever the destination is not a known contact -- and a freshly discovered
+    neighbor never is, because nothing in this app populates the library's
+    contact cache. If that ever changes (an ``ensure_contacts()`` call
+    anywhere), a neighbor holding a stale multi-hop ``out_path`` would have its
+    scope query routed the long way instead of probed directly.
     """
     if not entries:
         return
@@ -391,27 +348,20 @@ async def collect_scopes(
             await asyncio.sleep(cfg.scope_gap)
 
         try:
-            with zero_hop_contact_override(meshcore, entry.pubkey, logger) as injected:
-                if not injected:
-                    # Nothing was transmitted, so this is a send failure, not a
-                    # silent neighbor. Reporting it as a timeout would assert on
-                    # the topic that the neighbor was asked when it never was.
-                    entry.status = STATUS_SEND_FAILED
-                    continue
-                # Locked per request, not for the whole pass: a pass can span
-                # minutes and must not block the app's other device traffic.
-                async with _maybe_lock(command_lock):
-                    # Bounded: this holds the shared device-command lock, and an
-                    # unbounded stall here would block the connection watchdog
-                    # (and everything else) for as long as the write hangs.
-                    scopes = await asyncio.wait_for(
-                        meshcore.commands.req_regions_sync(
-                            entry.pubkey,
-                            timeout=timeout,
-                            min_timeout=cfg.scope_min_timeout,
-                        ),
-                        timeout=cfg.scope_request_budget,
-                    )
+            # Locked per request, not for the whole pass: a pass can span
+            # minutes and must not block the app's other device traffic.
+            async with _maybe_lock(command_lock):
+                # Bounded: this holds the shared device-command lock, and an
+                # unbounded stall here would block the connection watchdog
+                # (and everything else) for as long as the write hangs.
+                scopes = await asyncio.wait_for(
+                    meshcore.commands.req_regions_sync(
+                        entry.pubkey,
+                        timeout=timeout,
+                        min_timeout=cfg.scope_min_timeout,
+                    ),
+                    timeout=cfg.scope_request_budget,
+                )
         except asyncio.CancelledError:
             raise
         except asyncio.TimeoutError:

--- a/src/meshcore_packet_capture/neighbors.py
+++ b/src/meshcore_packet_capture/neighbors.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Zero-hop neighbor discovery and scope collection for the MQTT neighbors topic.
+
+Port of the observer firmware's WITH_MQTT_NEIGHBORS feature (see
+examples/simple_repeater/MyMesh.cpp). Two stages per cycle:
+
+1. A zero-hop node-discover request; repeaters answer with their pubkey and the
+   SNR we heard them at. Responses are collected for a fixed window.
+2. One anon-regions request per discovered neighbor, yielding that neighbor's
+   scope names.
+
+Both requests are issued through meshcore_py (``send_node_discover_req`` and
+``req_regions_sync``); nothing here re-encodes packets.
+
+Stage 2 is deliberately paced. The firmware originally fired every request at
+once and the responses collided, so it moved to one request in flight at a time
+(firmware commit aba571ed). ``req_regions_sync`` already gives us that — it
+awaits the response under a lock — so this module supplies the rest of that
+strategy: sort by usefulness *before* querying, let the device's own airtime
+estimate set each timeout, and leave a settle gap between requests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import time
+from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from meshcore import EventType
+
+# ADV_TYPE_REPEATER (enums.AdvertFlags.ADV_TYPE_REPEATER). The firmware discovers
+# repeaters only; the filter is a bitmask over advert types.
+ADV_TYPE_REPEATER = 0x02
+DISCOVER_FILTER_REPEATER = 1 << ADV_TYPE_REPEATER
+
+# Matches MQTTBridge::NEIGHBORS_JSON_BUFFER_SIZE. Entries past this budget are
+# dropped from the tail so the payload stays within the firmware's contract.
+NEIGHBORS_JSON_BUDGET = 10240
+
+@asynccontextmanager
+async def _maybe_lock(lock):
+    """Hold ``lock`` if one was supplied, otherwise do nothing.
+
+    Device commands must not overlap: two concurrent writes to the BLE RX
+    characteristic drop the link. The caller owns the lock so neighbors requests
+    serialise against the app's other device traffic (status publishes, stats,
+    health checks), not just against each other.
+    """
+    if lock is None:
+        yield
+    else:
+        async with lock:
+            yield
+
+
+STATUS_RESPONDED = "responded"
+STATUS_TIMEOUT = "timeout"
+STATUS_SEND_FAILED = "send_failed"
+
+# Firmware interval band (MQTTPrefsStorage.h).
+MIN_INTERVAL_HOURS = 12
+MAX_INTERVAL_HOURS = 336
+DEFAULT_INTERVAL_HOURS = 24
+
+# Floors that keep a misconfiguration from producing an empty snapshot forever.
+# Repeaters answer a discover request after a randomised delay, so a very short
+# window collects nothing at all.
+MIN_DISCOVER_WINDOW = 5.0
+MIN_CYCLE_TIMEOUT = 10.0
+MIN_COMMAND_TIMEOUT = 1.0
+
+# meshcore_py's CommandHandlerBase.DEFAULT_TIMEOUT: how long req_regions_sync
+# waits for MSG_SENT before it even begins waiting for the response.
+LIBRARY_MSG_SENT_TIMEOUT = 15.0
+
+
+def clamp_interval_hours(hours: int) -> int:
+    """Clamp to the firmware's 12-336h band, falling back to the 24h default."""
+    if hours <= 0:
+        return DEFAULT_INTERVAL_HOURS
+    return max(MIN_INTERVAL_HOURS, min(MAX_INTERVAL_HOURS, hours))
+
+
+@dataclass
+class NeighborsConfig:
+    """Tuning for one neighbors cycle. Defaults mirror the firmware."""
+
+    interval_hours: int = DEFAULT_INTERVAL_HOURS
+    discover_window: float = 60.0     # stage 1 collection window
+    command_timeout: float = 20.0     # cap on the discover request itself
+    scope_timeout: float = 0.0        # 0 = let the device suggest it
+    scope_min_timeout: float = 8.0    # floor under the suggested timeout
+    scope_gap: float = 2.0            # settle delay between scope requests
+    cycle_timeout: float = 600.0      # overall budget for the scope pass
+    max_neighbors: int = 32
+    self_scopes: str = ""             # explicit override; "" = ask the device
+
+    def __post_init__(self):
+        # Values that would silently produce a permanently empty snapshot get a
+        # floor rather than being honoured: a 0s discover window collects nothing,
+        # and max_neighbors = 0 queries nobody.
+        self.interval_hours = clamp_interval_hours(self.interval_hours)
+        if self.discover_window < MIN_DISCOVER_WINDOW:
+            self.discover_window = MIN_DISCOVER_WINDOW
+        if self.max_neighbors < 1:
+            self.max_neighbors = 1
+        if self.cycle_timeout < MIN_CYCLE_TIMEOUT:
+            self.cycle_timeout = MIN_CYCLE_TIMEOUT
+        if self.scope_gap < 0:
+            self.scope_gap = 0.0
+        # wait_for(timeout=0) raises immediately, so 0 here would break every
+        # cycle forever -- and it reads as "no cap" by analogy with scope_timeout.
+        if self.command_timeout < MIN_COMMAND_TIMEOUT:
+            self.command_timeout = MIN_COMMAND_TIMEOUT
+
+    @property
+    def scope_request_budget(self) -> float:
+        """Hard ceiling on one scope request, covering the lock it holds.
+
+        req_regions_sync waits for MSG_SENT (the library default, 15s) and then
+        for the response, so the budget has to exceed both or healthy requests
+        would be cut off.
+        """
+        wait = self.scope_timeout if self.scope_timeout > 0 else self.scope_min_timeout
+        return LIBRARY_MSG_SENT_TIMEOUT + max(wait, self.scope_min_timeout) + self.command_timeout
+
+    @property
+    def interval_seconds(self) -> float:
+        return self.interval_hours * 3600.0
+
+
+@dataclass
+class NeighborEntry:
+    """One discovered neighbor. Snapshotted so later table changes can't alter it."""
+
+    pubkey: str
+    snr: float
+    heard_at: float                   # monotonic-ish wall clock of the response
+    scopes: str = ""
+    status: str = STATUS_TIMEOUT
+
+    def heard_secs_ago(self, now: Optional[float] = None) -> int:
+        now = time.time() if now is None else now
+        return max(0, int(now - self.heard_at))
+
+
+def sort_key(entry: NeighborEntry, now: Optional[float] = None) -> tuple:
+    """Firmware ordering: most recently heard, then stronger SNR, then pubkey.
+
+    Mirrors neighborPublishEntryComesBefore() and the pre-query sort added in
+    firmware commit aba571ed, so query order and publish order agree — a
+    truncated cycle still covers the most useful neighbors.
+
+    Recency is compared as the published heard_secs_ago, ascending -- the exact
+    value the firmware's comparator uses. Sorting on the raw float clock instead
+    would quantise differently from the field we publish, so the output could be
+    non-monotonic in heard_secs_ago, and SNR would never break a tie: the most
+    recent response would always win outright. That matters because this order
+    decides which entries survive the payload budget.
+    """
+    return (entry.heard_secs_ago(now), -entry.snr, entry.pubkey)
+
+
+def sort_entries(entries: list[NeighborEntry],
+                 now: Optional[float] = None) -> list[NeighborEntry]:
+    # One `now` for the whole sort, and the same one the payload uses, so the
+    # published heard_secs_ago values are ordered exactly as sorted.
+    now = time.time() if now is None else now
+    return sorted(entries, key=lambda e: sort_key(e, now))
+
+
+async def discover_neighbors(
+    meshcore,
+    cfg: NeighborsConfig,
+    self_pubkey: Optional[str],
+    logger,
+    *,
+    debug: bool = False,
+    still_valid=None,
+    command_lock=None,
+) -> Optional[list[NeighborEntry]]:
+    """Stage 1: zero-hop node-discover, collecting responses for the window.
+
+    Returns the discovered entries (possibly empty), or None if the request
+    could not be sent or the session was invalidated mid-window.
+
+    ``still_valid`` is an optional predicate that must keep returning True for
+    the collected data to mean anything. A reconnect part-way through the window
+    tears down every event subscription (the app clears them wholesale), so our
+    response handler silently stops firing -- without this check the cycle would
+    happily publish "0 neighbours" as though the mesh were empty.
+    """
+    collected: dict[str, NeighborEntry] = {}
+    self_key = (self_pubkey or "").lower()
+    # EventDispatcher spawns async callbacks as background tasks, so an event
+    # already dequeued can still reach the handler after unsubscribe() returns.
+    # This latch keeps a straggler from mutating entries we have already returned.
+    closed = False
+
+    # Generate the tag ourselves rather than letting the library pick one, so it is
+    # known *before* the subscription goes live. Otherwise a response arriving
+    # between subscribe and send-completion would be accepted with no tag check --
+    # which is how a stale round, or another client's round, could leak in.
+    # DISCOVER_RESPONSE reports the tag as little-endian hex.
+    tag = random.randint(1, 0xFFFFFFFF)
+    expected_tag = tag.to_bytes(4, "little").hex()
+
+    async def on_discover_response(event):
+        if closed:
+            return
+        payload = getattr(event, "payload", None) or {}
+        pubkey = str(payload.get("pubkey", "")).lower()
+        # Full 32-byte pubkeys only; the firmware rejects short prefixes too.
+        if len(pubkey) != 64:
+            return
+        if self_key and pubkey == self_key:
+            return
+        if payload.get("node_type") != ADV_TYPE_REPEATER:
+            return
+        if str(payload.get("tag", "")).lower() != expected_tag:
+            return
+
+        snr = float(payload.get("SNR", 0) or 0)
+        existing = collected.get(pubkey)
+        if existing is None:
+            collected[pubkey] = NeighborEntry(pubkey=pubkey, snr=snr, heard_at=time.time())
+        else:
+            # Same neighbor heard again (repeaters delay responses randomly).
+            # putNeighbour() refreshes the timestamp on every response, so do
+            # that unconditionally; keep the strongest SNR seen.
+            existing.heard_at = time.time()
+            existing.snr = max(existing.snr, snr)
+
+    # Subscribe per-run rather than at startup: cleanup_event_subscriptions()
+    # drops every subscription on reconnect, and this handler is only wanted for
+    # the duration of the window.
+    subscription = meshcore.subscribe(EventType.DISCOVER_RESPONSE, on_discover_response)
+    try:
+        # Bounded: on a stalled link the underlying BLE/serial write can block far
+        # longer than the library's own response timeout, and an unbounded wait
+        # here stalls the whole cycle (and, for a one-shot run, startup).
+        try:
+            async with _maybe_lock(command_lock):
+                result = await asyncio.wait_for(
+                    meshcore.commands.send_node_discover_req(
+                        DISCOVER_FILTER_REPEATER,
+                        prefix_only=False,   # we need the full 32-byte pubkey
+                        tag=tag,
+                    ),
+                    timeout=cfg.command_timeout,
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Neighbors: node-discover request did not complete within "
+                f"{cfg.command_timeout:.0f}s, abandoning this cycle"
+            )
+            return None
+
+        if result is None or result.type == EventType.ERROR:
+            reason = ""
+            if result is not None:
+                reason = (getattr(result, "payload", None) or {}).get("reason", "")
+            # Logged at debug: the caller owns the user-facing message, because on a
+            # build that lacks the command this fails every cycle forever.
+            logger.debug(
+                f"Neighbors: node-discover request failed{f' ({reason})' if reason else ''}"
+            )
+            return None
+
+        if debug:
+            logger.debug(
+                f"Neighbors: node-discover sent (tag={expected_tag}), "
+                f"collecting for {cfg.discover_window:.0f}s"
+            )
+        await asyncio.sleep(cfg.discover_window)
+
+        if still_valid is not None and not still_valid():
+            logger.warning(
+                "Neighbors: device session was reset during the discovery window "
+                "(event subscriptions are torn down on reconnect), abandoning this cycle"
+            )
+            return None
+    finally:
+        closed = True
+        try:
+            meshcore.unsubscribe(subscription)
+        except Exception as exc:
+            logger.debug(f"Neighbors: error unsubscribing discover handler: {exc}")
+
+    return sort_entries(list(collected.values()))
+
+
+def _zero_hop_contact(pubkey: str) -> dict[str, Any]:
+    """A synthetic zero-hop contact entry for the library's contact cache.
+
+    ``send_anon_req`` refuses to send unless the target resolves in the client
+    cache, and uses the entry only to build the reply-path bytes. The companion
+    firmware needs no such contact — CMD_SEND_ANON_REQ synthesises a transient
+    one (out_path_len = 0, hidden from CMD_GET_CONTACTS, never persisted; see
+    companion_radio/MyMesh.cpp and BaseChatMesh::allocateContactSlot).
+
+    out_path_len = 0 keeps the library off its out_path_len == -1 branch, so it
+    issues no change_contact_path/reset_path writes to the device, and the
+    request carries an empty reply path -- the zero-hop direct probe the
+    firmware feature sends.
+    """
+    return {
+        "public_key": pubkey,
+        "out_path_len": 0,
+        "out_path": "",
+        "adv_name": "",
+        "type": 0,
+    }
+
+
+@contextmanager
+def zero_hop_contact_override(meshcore, pubkey: str, logger):
+    """Temporarily force ``pubkey`` to resolve as a zero-hop contact.
+
+    Yields True when the override is in place, False when the contact cache is
+    unavailable — callers must treat False as "no request can be sent", because
+    ``req_regions_sync`` would report ``contact_not_found`` and, since it maps
+    every failure to ``None``, that would be indistinguishable from a neighbor
+    that simply didn't answer.
+
+    The cache is keyed by public_key (see MeshCore._update_contacts), so writing
+    under the same key overrides any real contact - including one carrying a
+    stale multi-hop path that would otherwise route the probe the long way - and
+    restores it exactly on exit.
+    """
+    # Public property; returns the same dict object the library mutates.
+    contacts = getattr(meshcore, "contacts", None)
+    if not isinstance(contacts, dict):
+        logger.warning("Neighbors: contact cache unavailable, cannot issue scope requests")
+        yield False
+        return
+
+    had_original = pubkey in contacts
+    original = contacts.get(pubkey)
+    contacts[pubkey] = _zero_hop_contact(pubkey)
+    try:
+        yield True
+    finally:
+        if had_original:
+            contacts[pubkey] = original
+        else:
+            contacts.pop(pubkey, None)
+
+
+async def collect_scopes(
+    meshcore,
+    entries: list[NeighborEntry],
+    cfg: NeighborsConfig,
+    logger,
+    *,
+    debug: bool = False,
+    command_lock=None,
+) -> None:
+    """Stage 2: one anon-regions request per neighbor, paced, updating in place.
+
+    Entries must already be sorted (see sort_entries) so that if the cycle
+    budget runs out the most useful neighbors have been covered. Anything not
+    reached keeps its initial ``timeout`` status, matching the firmware's
+    fallback.
+    """
+    if not entries:
+        return
+
+    deadline = time.time() + cfg.cycle_timeout
+    # 0 means "let the device decide": req_regions_sync derives the wait from the
+    # suggested_timeout the radio returns, which is its own airtime estimate.
+    timeout = cfg.scope_timeout if cfg.scope_timeout > 0 else 0
+
+    for index, entry in enumerate(entries):
+        if time.time() >= deadline:
+            dropped = len(entries) - index
+            logger.warning(
+                f"Neighbors: cycle budget ({cfg.cycle_timeout:.0f}s) reached, "
+                f"{dropped} of {len(entries)} neighbor(s) left unqueried (reported as timeout)"
+            )
+            break
+
+        # Settle gap between requests, standing in for the firmware's
+        # wait-for-TX-completion gating.
+        if index > 0 and cfg.scope_gap > 0:
+            await asyncio.sleep(cfg.scope_gap)
+
+        try:
+            with zero_hop_contact_override(meshcore, entry.pubkey, logger) as injected:
+                if not injected:
+                    # Nothing was transmitted, so this is a send failure, not a
+                    # silent neighbor. Reporting it as a timeout would assert on
+                    # the topic that the neighbor was asked when it never was.
+                    entry.status = STATUS_SEND_FAILED
+                    continue
+                # Locked per request, not for the whole pass: a pass can span
+                # minutes and must not block the app's other device traffic.
+                async with _maybe_lock(command_lock):
+                    # Bounded: this holds the shared device-command lock, and an
+                    # unbounded stall here would block the connection watchdog
+                    # (and everything else) for as long as the write hangs.
+                    scopes = await asyncio.wait_for(
+                        meshcore.commands.req_regions_sync(
+                            entry.pubkey,
+                            timeout=timeout,
+                            min_timeout=cfg.scope_min_timeout,
+                        ),
+                        timeout=cfg.scope_request_budget,
+                    )
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            entry.status = STATUS_SEND_FAILED
+            logger.warning(
+                f"Neighbors: scope request to {entry.pubkey[:12]} exceeded "
+                f"{cfg.scope_request_budget:.0f}s; the device link may be stalled"
+            )
+            continue
+        except Exception as exc:
+            entry.status = STATUS_SEND_FAILED
+            logger.debug(f"Neighbors: scope request to {entry.pubkey[:12]} failed: {exc}")
+            continue
+
+        if scopes is None:
+            # req_regions_sync collapses every failure to None: a real timeout,
+            # but also a device-level send rejection. We report timeout, which is
+            # the firmware's own fallback for anything that isn't a clean send
+            # failure or response.
+            entry.status = STATUS_TIMEOUT
+            if debug:
+                logger.debug(f"Neighbors: no scope response from {entry.pubkey[:12]}")
+            continue
+
+        entry.scopes = str(scopes).strip()
+        entry.status = STATUS_RESPONDED
+        if debug:
+            logger.debug(
+                f"Neighbors: {entry.pubkey[:12]} scopes="
+                f"{entry.scopes if entry.scopes else '(none)'}"
+            )
+
+
+async def fetch_self_scopes(meshcore, cfg: NeighborsConfig, logger, command_lock=None) -> str:
+    """This node's own scope names for the message's ``self`` object.
+
+    A companion radio has no region_map, so the closest analogue to the
+    firmware's exportNamesTo(REGION_DENY_FLOOD) is the default flood scope name.
+    ``neighbors_self_scopes`` overrides it outright.
+    """
+    if cfg.self_scopes:
+        return cfg.self_scopes
+
+    # A reconnect can null out the device handle mid-cycle (a cycle spans minutes).
+    commands = getattr(meshcore, "commands", None)
+    getter = getattr(commands, "get_default_flood_scope", None)
+    if not callable(getter):
+        return ""
+
+    try:
+        async with _maybe_lock(command_lock):
+            result = await asyncio.wait_for(getter(), timeout=cfg.command_timeout)
+    except Exception as exc:
+        logger.debug(f"Neighbors: could not read default flood scope: {exc}")
+        return ""
+
+    if result is None or result.type == EventType.ERROR:
+        return ""
+    return str((getattr(result, "payload", None) or {}).get("scope_name", "") or "").strip()
+
+
+def build_neighbors_message(
+    origin: str,
+    origin_id: str,
+    self_scopes: str,
+    entries: list[NeighborEntry],
+    *,
+    timestamp: Optional[str] = None,
+    now: Optional[float] = None,
+    budget: int = NEIGHBORS_JSON_BUDGET,
+    total_neighbors: Optional[int] = None,
+) -> tuple[dict[str, Any], int]:
+    """Build the neighbors payload, dropping the tail past ``budget`` bytes.
+
+    Matches MQTTPayloadBuilder::buildNeighborsMessage. Returns the message and
+    the number of entries dropped.
+    """
+    now = time.time() if now is None else now
+    # total_neighbors is how many were discovered before any max_neighbors cap;
+    # queried_neighbors is how many we actually asked. Firmware key order
+    # (MQTTPayloadBuilder.cpp): these sit between origin_id and self.
+    queried = len(entries)
+    total = queried if total_neighbors is None else total_neighbors
+    message: dict[str, Any] = {
+        "timestamp": timestamp or datetime.now(timezone.utc).isoformat(),
+        "origin": origin,
+        "origin_id": origin_id,
+        "total_neighbors": total,
+        "queried_neighbors": queried,
+        # Set below once we know whether the payload budget dropped a tail.
+        "truncated": total > queried,
+        "self": {"scopes": self_scopes or ""},
+        "neighbors": [],
+    }
+
+    neighbors = message["neighbors"]
+    dropped = 0
+    for position, entry in enumerate(sort_entries(entries, now)):
+        neighbors.append(
+            {
+                "pubkey": entry.pubkey.upper(),
+                "snr": entry.snr,
+                "heard_secs_ago": entry.heard_secs_ago(now),
+                "scopes": entry.scopes or "",
+                "status": entry.status,
+            }
+        )
+        # Entries are ordered most- to least-useful, so once one overflows, drop
+        # it and everything after it.
+        if len(json.dumps(message)) >= budget:
+            neighbors.pop()
+            dropped = len(entries) - position
+            break
+
+    # Truncated covers both causes: the max_neighbors cap and the payload budget.
+    message["truncated"] = bool(dropped) or total > queried
+    return message, dropped

--- a/src/meshcore_packet_capture/packet_capture.py
+++ b/src/meshcore_packet_capture/packet_capture.py
@@ -42,6 +42,14 @@ from .payload_decode import (
     ChannelKeyStore,
     decode_payload,
 )
+from .neighbors import (
+    NeighborsConfig,
+    build_neighbors_message,
+    clamp_interval_hours,
+    collect_scopes,
+    discover_neighbors,
+    fetch_self_scopes,
+)
 
 # Import MQTT client
 try:
@@ -442,7 +450,6 @@ class PacketCapture:
         # lock, so a legitimately slow predecessor doesn't cause spurious giveups.
         self.device_lock_wait_margin = self.get_env_float('DEVICE_LOCK_WAIT_MARGIN', 30.0)
         
-        
         # Service-level failure tracking for systemd restart
         self.service_failure_count = 0
         self.max_service_failures = self.get_env_int('MAX_SERVICE_FAILURES', 3)
@@ -488,9 +495,38 @@ class PacketCapture:
         self.advert_interval_hours = self.get_env_int('ADVERT_INTERVAL_HOURS', 47)
         self.last_advert_time = 0
         self.advert_task = None
-        
+
         # Load persisted advert state
         self.last_advert_time = self._load_advert_state()
+
+        # Neighbors publishing (see neighbors.py). Enabled per broker; the cycle
+        # only runs when at least one connected broker has opted in.
+        requested_neighbors_interval = self.get_env_int('NEIGHBORS_INTERVAL_HOURS', 24)
+        self.neighbors_config = NeighborsConfig(
+            interval_hours=requested_neighbors_interval,
+            discover_window=self.get_env_float('NEIGHBORS_DISCOVER_WINDOW', 60.0),
+            command_timeout=self.get_env_float('NEIGHBORS_COMMAND_TIMEOUT', 20.0),
+            scope_timeout=self.get_env_float('NEIGHBORS_SCOPE_TIMEOUT', 0.0),
+            scope_min_timeout=self.get_env_float('NEIGHBORS_SCOPE_MIN_TIMEOUT', 8.0),
+            scope_gap=self.get_env_float('NEIGHBORS_SCOPE_GAP', 2.0),
+            cycle_timeout=self.get_env_float('NEIGHBORS_CYCLE_TIMEOUT', 600.0),
+            max_neighbors=self.get_env_int('NEIGHBORS_MAX', 32),
+            self_scopes=self.get_env('NEIGHBORS_SELF_SCOPES', '').strip(),
+        )
+        # NeighborsConfig clamps out-of-range values; say so rather than silently
+        # running on a number the operator didn't ask for.
+        if self.neighbors_config.interval_hours != requested_neighbors_interval:
+            self.logger.warning(
+                f"neighbors_interval_hours {requested_neighbors_interval} is outside the "
+                f"supported 12-336h range, using {self.neighbors_config.interval_hours}h"
+            )
+        self.neighbors_task = None
+        self.neighbors_capability_state = None
+        self.neighbors_discover_failures = 0
+        # Set by --neighbors-now / --neighbors-exit (see main()).
+        self.neighbors_run_now = False
+        self.neighbors_exit_after_run = False
+        self.last_neighbors_publish = self._load_neighbors_state()
         
         # Packet type filtering for uploads
         upload_types_str = self.get_env('UPLOAD_PACKET_TYPES', '').strip()
@@ -654,6 +690,35 @@ class PacketCapture:
             return self.include_decoded
         return val.strip().lower() in ('true', '1', 'yes', 'on')
 
+    def _broker_wants_neighbors(self, broker_num) -> bool:
+        """Per-broker opt-in for the neighbors topic. Off unless set, like the firmware."""
+        val = self.get_env(f'MQTT{broker_num}_NEIGHBORS', '')
+        return val.strip().lower() in ('true', '1', 'yes', 'on')
+
+    def neighbors_broker_nums(self, warn_unroutable: bool = False) -> list:
+        """Enabled brokers that opted into neighbors publishing *and* can route it.
+
+        A broker that opted in but whose neighbors topic cannot resolve (no IATA
+        and no explicit override) is excluded: including it would spend a full
+        discover window plus one on-air scope request per neighbor every cycle and
+        then discard the result.
+        """
+        opted_in = [
+            n for n in self.iter_configured_mqtt_brokers()
+            if self.get_env_bool(f'MQTT{n}_ENABLED', False) and self._broker_wants_neighbors(n)
+        ]
+        routable = []
+        for n in opted_in:
+            if self.get_topic('NEIGHBORS', n):
+                routable.append(n)
+            elif warn_unroutable:
+                self.logger.warning(
+                    f"{self.get_broker_label(n)} has neighbors enabled but no neighbors topic "
+                    "could be resolved (set an IATA code or a per-broker neighbors topic); "
+                    "skipping it"
+                )
+        return routable
+
     def _get_state_file_path(self):
         """Get the path to the state file for persisting last_advert_time.
         
@@ -677,75 +742,119 @@ class PacketCapture:
         # Fall back to script directory (works for all installation methods)
         return os.path.join(script_dir, 'advert_state.json')
     
-    def _load_advert_state(self):
-        """Load last_advert_time from persistent state file.
-        
-        Returns the timestamp if found, otherwise returns 0.
-        """
+    def _read_state_dict(self) -> dict:
+        """Read the whole state file. Returns {} when missing or unreadable."""
         state_file = self._get_state_file_path()
-        
+
         if not os.path.exists(state_file):
             if self.debug:
-                self.logger.debug(f"Advert state file not found: {state_file}")
-            return 0
-        
+                self.logger.debug(f"State file not found: {state_file}")
+            return {}
+
         try:
             with open(state_file, 'r') as f:
                 state = json.load(f)
-                last_time = state.get('last_advert_time', 0)
-                
-                # Validate the timestamp is reasonable (not in the future, not too old)
-                current_time = time.time()
-                if last_time > current_time:
-                    # Timestamp is in the future, ignore it
-                    if self.debug:
-                        self.logger.debug(f"Advert state timestamp is in the future, ignoring: {last_time}")
-                    return 0
-                
-                # If timestamp is more than 1 year old, treat as invalid
-                if current_time - last_time > 31536000:  # 1 year in seconds
-                    if self.debug:
-                        self.logger.debug(f"Advert state timestamp is too old, ignoring: {last_time}")
-                    return 0
-                
-                if self.debug:
-                    self.logger.debug(f"Loaded last_advert_time from state file: {last_time} ({datetime.fromtimestamp(last_time).isoformat()})")
-                return last_time
-                
+            return state if isinstance(state, dict) else {}
         except (json.JSONDecodeError, IOError, OSError) as e:
-            self.logger.warning(f"Failed to load advert state from {state_file}: {e}")
+            self.logger.warning(f"Failed to load state from {state_file}: {e}")
+            return {}
+
+    def _validate_state_timestamp(self, value, label: str) -> float:
+        """Reject timestamps in the future or more than a year old."""
+        try:
+            timestamp = float(value or 0)
+        except (TypeError, ValueError):
             return 0
-    
-    def _save_advert_state(self):
-        """Save last_advert_time to persistent state file."""
+
+        if timestamp <= 0:
+            return 0
+
+        current_time = time.time()
+        if timestamp > current_time:
+            if self.debug:
+                self.logger.debug(f"{label} is in the future, ignoring: {timestamp}")
+            return 0
+        if current_time - timestamp > 31536000:  # 1 year in seconds
+            if self.debug:
+                self.logger.debug(f"{label} is too old, ignoring: {timestamp}")
+            return 0
+        return timestamp
+
+    def _write_state_updates(self, updates: dict, label: str) -> None:
+        """Merge ``updates`` into the state file and write it atomically.
+
+        Merging matters because advert and neighbors timestamps share one file;
+        a wholesale overwrite would drop whichever key wasn't being saved.
+        """
         state_file = self._get_state_file_path()
         state_dir = os.path.dirname(state_file)
-        
+
         try:
             # Create directory if it doesn't exist (for data subdirectory case)
             if state_dir and not os.path.exists(state_dir):
                 os.makedirs(state_dir, mode=0o755, exist_ok=True)
-            
-            state = {
-                'last_advert_time': self.last_advert_time,
-                'updated_at': time.time()
-            }
-            
+
+            state = self._read_state_dict()
+            state.update(updates)
+            state['updated_at'] = time.time()
+
             # Write atomically using a temporary file
             temp_file = state_file + '.tmp'
             with open(temp_file, 'w') as f:
                 json.dump(state, f, indent=2)
-            
+
             # Atomic rename
             os.replace(temp_file, state_file)
-            
+
             if self.debug:
-                self.logger.debug(f"Saved last_advert_time to state file: {self.last_advert_time} ({datetime.fromtimestamp(self.last_advert_time).isoformat()})")
-                
+                self.logger.debug(f"Saved {label} to state file: {updates}")
+
         except (IOError, OSError) as e:
-            self.logger.warning(f"Failed to save advert state to {state_file}: {e}")
-    
-    
+            self.logger.warning(f"Failed to save {label} to {state_file}: {e}")
+
+    def _load_advert_state(self):
+        """Load last_advert_time from persistent state file.
+
+        Returns the timestamp if found, otherwise returns 0.
+        """
+        last_time = self._validate_state_timestamp(
+            self._read_state_dict().get('last_advert_time', 0), 'Advert state timestamp'
+        )
+        if last_time and self.debug:
+            self.logger.debug(
+                f"Loaded last_advert_time from state file: {last_time} "
+                f"({datetime.fromtimestamp(last_time).isoformat()})"
+            )
+        return last_time
+
+    def _save_advert_state(self):
+        """Save last_advert_time to persistent state file."""
+        self._write_state_updates({'last_advert_time': self.last_advert_time}, 'last_advert_time')
+
+    def _load_neighbors_state(self):
+        """Load last_neighbors_publish from persistent state file.
+
+        Neighbors intervals are long (12-336h), so surviving a restart is what
+        keeps the schedule honest instead of republishing on every boot.
+        """
+        last_time = self._validate_state_timestamp(
+            self._read_state_dict().get('last_neighbors_publish', 0),
+            'Neighbors state timestamp',
+        )
+        if last_time and self.debug:
+            self.logger.debug(
+                f"Loaded last_neighbors_publish from state file: {last_time} "
+                f"({datetime.fromtimestamp(last_time).isoformat()})"
+            )
+        return last_time
+
+    def _save_neighbors_state(self):
+        """Save last_neighbors_publish to persistent state file."""
+        self._write_state_updates(
+            {'last_neighbors_publish': self.last_neighbors_publish}, 'last_neighbors_publish'
+        )
+
+
     def calculate_connection_retry_delay(self, attempt: int) -> float:
         """Calculate exponential backoff delay with jitter for connection retries"""
         import random
@@ -892,7 +1001,6 @@ class PacketCapture:
                     )
                 finally:
                     self.device_command_lock.release()
-                
                 
                 # Check if result is an error
                 if result and hasattr(result, 'type'):
@@ -1133,8 +1241,14 @@ class PacketCapture:
         if self.is_letsmesh_broker(broker_num):
             return True
         
-        # Check if any configured topics use IATA placeholders
+        # Check if any configured topics use IATA placeholders. NEIGHBORS counts
+        # only when this broker actually opted in: otherwise a global
+        # [topics] neighbors template would disable an unrelated broker outright,
+        # which also contradicts neighbors_broker_nums() merely skipping
+        # unroutable brokers.
         topic_types = ['STATUS', 'PACKETS', 'DECODED', 'DEBUG', 'RAW']
+        if self._broker_wants_neighbors(broker_num):
+            topic_types = topic_types + ['NEIGHBORS']
         for topic_type in topic_types:
             # Check broker-specific topic
             broker_topic = self.get_env(f'MQTT{broker_num}_TOPIC_{topic_type}', '')
@@ -1169,6 +1283,17 @@ class PacketCapture:
             if self.debug:
                 self.logger.debug(f"No RAW topic configured for broker {broker_num}, skipping RAW publish")
             return None
+
+        # NEIGHBORS has no classic flat default: the firmware only routes it on
+        # MeshCore-style topics, which require an IATA. Without one, the broker
+        # must set the topic explicitly.
+        if topic_type_upper == 'NEIGHBORS' and not self.has_configured_iata(broker_num):
+            if self.debug:
+                self.logger.debug(
+                    f"No NEIGHBORS topic configured for broker {broker_num} and no IATA set, "
+                    "skipping NEIGHBORS publish"
+                )
+            return None
         
         # Defaulting policy adjustment:
         # - Never use classic defaults (meshcore/status, meshcore/packets, etc.) for Let's Mesh Analyzer brokers
@@ -1182,7 +1307,8 @@ class PacketCapture:
             'STATUS': 'meshcore/{IATA}/{PUBLIC_KEY}/status',
             'PACKETS': 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
             'DECODED': 'meshcore/{IATA}/{PUBLIC_KEY}/decoded',
-            'DEBUG': 'meshcore/{IATA}/{PUBLIC_KEY}/debug'
+            'DEBUG': 'meshcore/{IATA}/{PUBLIC_KEY}/debug',
+            'NEIGHBORS': 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors'
         }
         classic_defaults = {
             'STATUS': 'meshcore/status',
@@ -2892,6 +3018,15 @@ class PacketCapture:
                     self.logger.warning(f"{broker_label} client not connected - skipping publish")
                     continue
 
+                # Neighbors is opt-in per broker (the firmware defaults it off too).
+                if topic_type and topic_type.upper() == 'NEIGHBORS' \
+                        and not self._broker_wants_neighbors(current_broker_num):
+                    if self.debug:
+                        self.logger.debug(
+                            f"Skipping NEIGHBORS publish to {broker_label} - not enabled for this broker"
+                        )
+                    continue
+
                 # CRITICAL FIX: Resolve topic properly
                 if topic_type:
                     resolved_topic = self.get_topic(topic_type, current_broker_num)
@@ -3683,8 +3818,18 @@ class PacketCapture:
         # Start stats refresh scheduler
         if self.stats_status_enabled and self.stats_refresh_interval > 0:
             self.stats_update_task = asyncio.create_task(self.stats_refresh_scheduler())
-        
-        
+
+        # Manual one-shot neighbors run (--neighbors-now), before the scheduler so a
+        # test run can't race a scheduled cycle for the device's request lock.
+        if self.neighbors_run_now:
+            await self.run_manual_neighbors_cycle()
+
+        # Start neighbors scheduler (only if a broker opted in and can route it)
+        if (not self.should_exit and self.enable_mqtt
+                and self.neighbors_broker_nums(warn_unroutable=True)):
+            self.neighbors_task = asyncio.create_task(self.neighbors_scheduler())
+
+
         try:
             while not self.should_exit:
                 current_time = time.time()
@@ -3720,7 +3865,9 @@ class PacketCapture:
                 self.jwt_renewal_task.cancel()
             if self.stats_update_task:
                 self.stats_update_task.cancel()
-            
+            if self.neighbors_task:
+                self.neighbors_task.cancel()
+
             # Cancel all tracked active tasks
             for task in self.active_tasks.copy():
                 task.cancel()
@@ -3745,7 +3892,12 @@ class PacketCapture:
                     await self.stats_update_task
                 except asyncio.CancelledError:
                     pass
-            
+            if self.neighbors_task:
+                try:
+                    await self.neighbors_task
+                except asyncio.CancelledError:
+                    pass
+
             # Wait for all active tasks to complete
             if self.active_tasks:
                 await asyncio.gather(*self.active_tasks, return_exceptions=True)
@@ -3886,6 +4038,216 @@ class PacketCapture:
                 if await self.wait_with_shutdown(60):
                     break  # Shutdown was requested
     
+    def neighbors_commands_available(self) -> bool:
+        """Detect whether the connected build exposes the neighbors commands.
+
+        ``send_node_discover_req`` needs companion CMD_SEND_CONTROL_DATA (v8+) and
+        ``req_regions_sync`` needs CMD_SEND_ANON_REQ; older firmware or older
+        meshcore_py lacks them. Logged once per state change, like stats.
+        """
+        if not self.meshcore or not hasattr(self.meshcore, "commands"):
+            return False
+
+        commands = self.meshcore.commands
+        required = ["send_node_discover_req", "req_regions_sync"]
+        available = all(callable(getattr(commands, attr, None)) for attr in required)
+        state = "available" if available else "missing"
+        if state != self.neighbors_capability_state:
+            if available:
+                self.logger.info("MeshCore neighbors commands detected - neighbors publishing enabled")
+            else:
+                self.logger.warning(
+                    "MeshCore neighbors commands not available - neighbors publishing disabled"
+                )
+            self.neighbors_capability_state = state
+        return available
+
+    async def run_neighbors_cycle(self) -> bool:
+        """Run one discover + scopes pass and publish the result.
+
+        Returns True when a payload was published. Mirrors the firmware's
+        two-stage cycle (see neighbors.py and MyMesh::loopNeighborDiscover).
+        """
+        if not self._ensure_connected("neighbors cycle", "debug"):
+            return False
+        if not self.enable_mqtt or not self.mqtt_connected:
+            if self.debug:
+                self.logger.debug("Neighbors cycle skipped: MQTT not connected")
+            return False
+        if not self.neighbors_broker_nums():
+            if self.debug:
+                self.logger.debug("Neighbors cycle skipped: no broker has neighbors enabled")
+            return False
+        if not self.neighbors_commands_available():
+            return False
+
+        cfg = self.neighbors_config
+        self.logger.info("Neighbors: starting discovery cycle")
+
+        # A reconnect swaps in a fresh MeshCore object and clears every event
+        # subscription, so a cycle spanning one is collecting into a dead handler.
+        session = self.meshcore
+
+        def session_intact():
+            return self.meshcore is session and self.connected
+
+        entries = await discover_neighbors(
+            self.meshcore,
+            cfg,
+            self.device_public_key,
+            self.logger,
+            debug=self.debug,
+            still_valid=session_intact,
+            command_lock=self.device_command_lock,
+        )
+        if entries is None:
+            # A build that rejects the discover command fails every cycle; warn once
+            # rather than every wakeup forever.
+            self.neighbors_discover_failures += 1
+            if self.neighbors_discover_failures == 1:
+                self.logger.warning(
+                    "Neighbors: discovery request failed; will keep retrying quietly "
+                    "on the configured interval"
+                )
+            else:
+                self.logger.debug(
+                    f"Neighbors: discovery request failed "
+                    f"({self.neighbors_discover_failures} consecutive)"
+                )
+            return False
+        self.neighbors_discover_failures = 0
+
+        total_discovered = len(entries)
+        if len(entries) > cfg.max_neighbors:
+            self.logger.info(
+                f"Neighbors: {len(entries)} discovered, querying the {cfg.max_neighbors} most useful"
+            )
+            entries = entries[:cfg.max_neighbors]
+
+        self.logger.info(f"Neighbors: {len(entries)} neighbor(s) discovered, collecting scopes")
+        await collect_scopes(self.meshcore, entries, cfg, self.logger, debug=self.debug,
+                             command_lock=self.device_command_lock)
+
+        if not session_intact():
+            self.logger.warning(
+                "Neighbors: device session was reset during scope collection, "
+                "discarding this cycle rather than publishing partial data"
+            )
+            return False
+
+        self_scopes = await fetch_self_scopes(self.meshcore, cfg, self.logger,
+                                              self.device_command_lock)
+        origin_id = (
+            self.device_public_key.upper()
+            if self.device_public_key and self.device_public_key != 'Unknown'
+            else 'DEVICE'
+        )
+        message, dropped = build_neighbors_message(
+            self.device_name or self.get_env('ORIGIN', 'MeshCore Device'),
+            origin_id, self_scopes, entries,
+            total_neighbors=total_discovered,
+        )
+        if dropped:
+            self.logger.warning(
+                f"Neighbors: payload budget reached, dropped {dropped} least-useful entry(ies)"
+            )
+
+        # Non-retained: a snapshot taken every 12-336h is not a useful last-will value.
+        metrics = self.safe_publish(
+            None, json.dumps(message), retain=False, topic_type="neighbors"
+        )
+        responded = sum(1 for e in entries if e.status == 'responded')
+        if metrics['attempted'] == 0:
+            # Discovery cost real airtime, so a silent no-op here is worth flagging.
+            self.logger.warning(
+                f"Neighbors: collected {len(entries)} neighbor(s) but no broker accepted the "
+                "publish (check that a neighbors-enabled broker is connected)"
+            )
+        else:
+            self.logger.info(
+                f"Neighbors: published {len(message['neighbors'])} entry(ies) "
+                f"({responded} with scopes) to "
+                f"{metrics['succeeded']}/{metrics['attempted']} broker(s)"
+            )
+
+        # Record the attempt even if no broker accepted it, so a persistently
+        # failing publish can't turn into a discovery loop on every wakeup.
+        self.last_neighbors_publish = time.time()
+        self._save_neighbors_state()
+        return metrics['succeeded'] > 0
+
+    async def run_manual_neighbors_cycle(self):
+        """Handle --neighbors-now (and --neighbors-exit).
+
+        Extracted from start() so it is directly testable: a test-side copy of
+        this logic would pass while start() itself was broken.
+        """
+        if not self.enable_mqtt:
+            self.logger.error("--neighbors-now requires MQTT (remove --no-mqtt)")
+        elif not self.neighbors_broker_nums(warn_unroutable=True):
+            self.logger.error(
+                "--neighbors-now: no enabled broker has neighbors = true with a "
+                "resolvable neighbors topic"
+            )
+        else:
+            self.logger.info("Neighbors: running one cycle on request (--neighbors-now)")
+            # Hard cap: this runs inline before the main loop, so an unbounded
+            # stall here would hang startup outright. Derived from the same terms
+            # collect_scopes can actually spend, plus the self-scope query.
+            cfg = self.neighbors_config
+            budget = (cfg.discover_window + cfg.command_timeout + cfg.cycle_timeout
+                      + cfg.scope_request_budget + cfg.scope_gap + cfg.command_timeout)
+            try:
+                await asyncio.wait_for(self.run_neighbors_cycle(), timeout=budget)
+            except asyncio.TimeoutError:
+                self.logger.error(
+                    f"Neighbors: manual cycle exceeded {budget:.0f}s and was abandoned"
+                )
+            except Exception as e:
+                self.logger.error(f"Neighbors: manual cycle failed: {e}", exc_info=True)
+
+        if self.neighbors_exit_after_run:
+            self.logger.info("Neighbors: manual cycle complete, exiting (--neighbors-exit)")
+            self.should_exit = True
+
+    async def neighbors_scheduler(self):
+        """Background task publishing the neighbors topic on the configured interval."""
+        interval_seconds = self.neighbors_config.interval_seconds
+        if self.debug:
+            self.logger.debug(
+                f"Starting neighbors scheduler "
+                f"({clamp_interval_hours(self.neighbors_config.interval_hours)}h interval)"
+            )
+
+        while not self.should_exit:
+            try:
+                time_since_last = time.time() - self.last_neighbors_publish
+                if time_since_last < interval_seconds:
+                    sleep_time = interval_seconds - time_since_last
+                    if self.debug:
+                        self.logger.debug(f"Next neighbors publish in {sleep_time/3600:.1f} hours")
+                    if await self.wait_with_shutdown(sleep_time):
+                        break
+                    continue
+
+                await self.run_neighbors_cycle()
+
+                # run_neighbors_cycle stamps last_neighbors_publish on success. If it
+                # bailed early (not connected, no broker), back off before retrying
+                # so we re-check periodically rather than spinning.
+                if (time.time() - self.last_neighbors_publish) >= interval_seconds:
+                    if await self.wait_with_shutdown(300):
+                        break
+
+            except asyncio.CancelledError:
+                if self.debug:
+                    self.logger.debug("Neighbors scheduler cancelled")
+                break
+            except Exception as e:
+                self.logger.error(f"Error in neighbors scheduler: {e}")
+                if await self.wait_with_shutdown(300):
+                    break
+
     def seconds_until_next_renewal(self) -> float:
         """Seconds to sleep before the next JWT renewal check.
 
@@ -3949,6 +4311,18 @@ async def main():
     parser.add_argument('--debug', action='store_true', help='Enable debug output (shows all detailed debugging info)')
     parser.add_argument('--no-mqtt', action='store_true', help='Disable MQTT publishing')
     parser.add_argument(
+        '--neighbors-now',
+        action='store_true',
+        help='Run one neighbors discovery + scopes cycle immediately, ignoring the '
+             'schedule (the equivalent of the firmware\'s "discover.neighbors"). '
+             'Combine with --neighbors-exit to run just that and quit.',
+    )
+    parser.add_argument(
+        '--neighbors-exit',
+        action='store_true',
+        help='With --neighbors-now, exit once the cycle finishes instead of continuing to capture.',
+    )
+    parser.add_argument(
         '--config',
         action='append',
         dest='config_files',
@@ -3984,6 +4358,14 @@ async def main():
         enable_mqtt=not args.no_mqtt,
         shutdown_event=shutdown_event
     )
+
+    # Manual neighbors trigger: the firmware has a `discover.neighbors` CLI command,
+    # and the 12h minimum interval makes waiting for the scheduler impractical when
+    # testing. Runs once the device and brokers are up.
+    capture.neighbors_run_now = args.neighbors_now
+    capture.neighbors_exit_after_run = args.neighbors_exit
+    if args.neighbors_exit and not args.neighbors_now:
+        capture.logger.warning("--neighbors-exit has no effect without --neighbors-now")
     
     # Command line arguments override environment variable
     if args.debug:

--- a/src/meshcore_packet_capture/packet_capture.py
+++ b/src/meshcore_packet_capture/packet_capture.py
@@ -328,6 +328,51 @@ class _RotatingPacketLog:
             self._fh.close()
 
 
+class TaskReentrantLock:
+    """An asyncio lock that the task already holding it may re-acquire.
+
+    Device commands legitimately nest: JWT creation holds the lock across the
+    whole multi-frame signing sequence, and its private-key fallback goes through
+    retryable_device_command(), which wants the same lock. A plain asyncio.Lock
+    deadlocks there. Re-entry is scoped to the owning task, so genuine
+    concurrency from other tasks is still serialised - which is the point, since
+    two overlapping device writes drop the BLE link.
+    """
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self._owner = None
+        self._depth = 0
+
+    async def acquire(self) -> bool:
+        task = asyncio.current_task()
+        if self._owner is not None and self._owner is task:
+            self._depth += 1
+            return True
+        await self._lock.acquire()
+        self._owner = task
+        self._depth = 1
+        return True
+
+    def release(self) -> None:
+        if self._depth == 0:
+            raise RuntimeError("release() called on an unlocked TaskReentrantLock")
+        self._depth -= 1
+        if self._depth == 0:
+            self._owner = None
+            self._lock.release()
+
+    def locked(self) -> bool:
+        return self._lock.locked()
+
+    async def __aenter__(self):
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.release()
+
+
 class PacketCapture:
     """Standalone packet capture using meshcore package"""
     
@@ -385,6 +430,18 @@ class PacketCapture:
         self.stats_capability_state = None
         self.stats_update_task = None
         self.stats_fetch_lock = asyncio.Lock()
+
+        # Serialises device commands. Two overlapping writes to the BLE RX
+        # characteristic drop the link ("BLE write failed: 19" on macOS,
+        # reproduced on hardware). meshcore_py gained a transport-level write lock,
+        # but this keeps us safe on released versions that lack it, where an
+        # unlucky overlap between e.g. a status publish and a neighbors discovery
+        # would take the radio down.
+        self.device_command_lock = TaskReentrantLock()
+        # Extra grace on top of a command's own timeout when queueing for the
+        # lock, so a legitimately slow predecessor doesn't cause spurious giveups.
+        self.device_lock_wait_margin = self.get_env_float('DEVICE_LOCK_WAIT_MARGIN', 30.0)
+        
         
         # Service-level failure tracking for systemd restart
         self.service_failure_count = 0
@@ -809,11 +866,33 @@ class PacketCapture:
                     await asyncio.sleep(current_delay)
                     current_delay *= backoff_multiplier  # Exponential backoff
                 
-                # Execute command with timeout
-                result = await asyncio.wait_for(
-                    command_func(),
-                    timeout=timeout
-                )
+                # Execute command with timeout. The lock is held only for the
+                # attempt itself, not across retry backoffs, so a retrying command
+                # doesn't lock out the rest of the app.
+                #
+                # Acquiring is bounded too. Waiting unbounded here would let a
+                # stalled holder block the connection watchdog, which is the one
+                # thing that can recover a stalled link -- its own timeout can't
+                # fire while it is still queued for the lock.
+                try:
+                    await asyncio.wait_for(
+                        self.device_command_lock.acquire(),
+                        timeout=timeout + self.device_lock_wait_margin,
+                    )
+                except asyncio.TimeoutError:
+                    last_error = f"{command_name} timed out waiting for the device lock"
+                    self.logger.warning(f"{last_error} (another command appears stalled)")
+                    if attempt < max_retries - 1:
+                        continue
+                    return None
+                try:
+                    result = await asyncio.wait_for(
+                        command_func(),
+                        timeout=timeout
+                    )
+                finally:
+                    self.device_command_lock.release()
+                
                 
                 # Check if result is an error
                 if result and hasattr(result, 'type'):
@@ -1404,11 +1483,17 @@ class PacketCapture:
         expiry_seconds = self.resolve_token_ttl(broker_num)
         # Use on-device signing (preferred) or private key method (fallback)
         # The create_jwt_with_private_key() method already logs which method was used
-        jwt_token = await self.create_jwt_with_private_key(
-            audience,
-            expiry_seconds=expiry_seconds,
-            broker_num=broker_num,
-        )
+        #
+        # Held under the device lock for the whole call: on-device signing is a
+        # multi-frame sequence (sign_start, N x sign_data, sign_finish) and any
+        # other command writing between two chunks means two concurrent writes,
+        # which drops the BLE link.
+        async with self.device_command_lock:
+            jwt_token = await self.create_jwt_with_private_key(
+                audience,
+                expiry_seconds=expiry_seconds,
+                broker_num=broker_num,
+            )
         if jwt_token:
             # Store token with expiry time if broker_num is provided
             if broker_num is not None:
@@ -3748,7 +3833,10 @@ class PacketCapture:
                 return False
             
             self.logger.info("Sending flood advert...")
-            await self.meshcore.commands.send_advert(flood=True)
+            # Under the device lock like every other command: a write overlapping
+            # another one drops the BLE link.
+            async with self.device_command_lock:
+                await self.meshcore.commands.send_advert(flood=True)
             self.last_advert_time = time.time()
             self._save_advert_state()  # Persist the timestamp
             self.logger.info("Flood advert sent successfully!")

--- a/src/meshcore_packet_capture/packet_capture.py
+++ b/src/meshcore_packet_capture/packet_capture.py
@@ -344,7 +344,8 @@ class TaskReentrantLock:
     retryable_device_command(), which wants the same lock. A plain asyncio.Lock
     deadlocks there. Re-entry is scoped to the owning task, so genuine
     concurrency from other tasks is still serialised - which is the point, since
-    two overlapping device writes drop the BLE link.
+    a command is a write plus a wait for its reply and the library serialises
+    neither (see device_command_lock in PacketCapture.__init__).
     """
 
     def __init__(self):
@@ -439,12 +440,21 @@ class PacketCapture:
         self.stats_update_task = None
         self.stats_fetch_lock = asyncio.Lock()
 
-        # Serialises device commands. Two overlapping writes to the BLE RX
-        # characteristic drop the link ("BLE write failed: 19" on macOS,
-        # reproduced on hardware). meshcore_py gained a transport-level write lock,
-        # but this keeps us safe on released versions that lack it, where an
-        # unlucky overlap between e.g. a status publish and a neighbors discovery
-        # would take the radio down.
+        # Serialises whole device commands. meshcore_py >= 2.3.8 (now our floor)
+        # serialises the BLE write itself, which is what stops two overlapping
+        # writes from dropping the link ("BLE write failed: 19" on macOS,
+        # reproduced on hardware). That fix makes this lock unnecessary for link
+        # safety, but not redundant, because it guards two things a per-write
+        # lock cannot:
+        #
+        #   - A command is a write *plus* a wait for its reply, and the library
+        #     does not serialise that pair -- CommandHandler.send() takes no lock
+        #     (only mesh/binary requests take _mesh_request_lock) and matches
+        #     replies by event type. Two commands in flight awaiting the same
+        #     event type can therefore take each other's response.
+        #   - Multi-frame sequences that must be atomic across several commands:
+        #     on-device JWT signing is sign_start, N x sign_data, sign_finish,
+        #     and no transport-level lock can express "hold all of these".
         self.device_command_lock = TaskReentrantLock()
         # Extra grace on top of a command's own timeout when queueing for the
         # lock, so a legitimately slow predecessor doesn't cause spurious giveups.
@@ -1611,9 +1621,10 @@ class PacketCapture:
         # The create_jwt_with_private_key() method already logs which method was used
         #
         # Held under the device lock for the whole call: on-device signing is a
-        # multi-frame sequence (sign_start, N x sign_data, sign_finish) and any
-        # other command writing between two chunks means two concurrent writes,
-        # which drops the BLE link.
+        # multi-frame sequence (sign_start, N x sign_data, sign_finish) that has
+        # to complete as a unit. The library's transport-level write lock cannot
+        # supply that -- it serialises single writes, so another command would
+        # still be free to interleave between two signing chunks.
         async with self.device_command_lock:
             jwt_token = await self.create_jwt_with_private_key(
                 audience,
@@ -3985,8 +3996,9 @@ class PacketCapture:
                 return False
             
             self.logger.info("Sending flood advert...")
-            # Under the device lock like every other command: a write overlapping
-            # another one drops the BLE link.
+            # Under the device lock like every other command: send_advert does
+            # not go through retryable_device_command(), so it would otherwise be
+            # the one command able to run concurrently with a reply-awaiting one.
             async with self.device_command_lock:
                 await self.meshcore.commands.send_advert(flood=True)
             self.last_advert_time = time.time()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,26 @@ import pytest
 def _install_dependency_stubs() -> None:
     if "meshcore" not in sys.modules:
         meshcore_stub = types.ModuleType("meshcore")
-        meshcore_stub.EventType = type("EventType", (), {"ERROR": "ERROR"})
+        # Mirror the real EventType members the package references, so modules
+        # importing them (e.g. neighbors.py) behave the same under the stub.
+        meshcore_stub.EventType = type(
+            "EventType",
+            (),
+            {
+                "ERROR": "ERROR",
+                "DISCOVER_RESPONSE": "discover_response",
+                "DEFAULT_FLOOD_SCOPE": "default_flood_scope",
+            },
+        )
         sys.modules["meshcore"] = meshcore_stub
 
     if "paho" not in sys.modules:
         paho_module = types.ModuleType("paho")
         mqtt_module = types.ModuleType("paho.mqtt")
         mqtt_client_module = types.ModuleType("paho.mqtt.client")
+        # Constants/helpers safe_publish() consults on every publish.
+        mqtt_client_module.MQTT_ERR_SUCCESS = 0
+        mqtt_client_module.error_string = lambda rc: f"rc={rc}"
         mqtt_module.client = mqtt_client_module
         paho_module.mqtt = mqtt_module
         sys.modules["paho"] = paho_module

--- a/tests/packet_capture/test_device_lock.py
+++ b/tests/packet_capture/test_device_lock.py
@@ -1,0 +1,125 @@
+"""Serialisation of device commands.
+
+Two overlapping writes to the BLE RX characteristic drop the link outright
+("BLE write failed: 19", reproduced on hardware). Nothing in the app guaranteed
+callers were sequential -- schedulers, health checks, JWT signing and user
+commands all issue independently -- so device commands are funnelled through a
+single lock. It is task-reentrant because the JWT path legitimately nests.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from meshcore_packet_capture import packet_capture as pc_mod
+from meshcore_packet_capture.packet_capture import PacketCapture
+
+
+@pytest.fixture
+def capture(monkeypatch: pytest.MonkeyPatch) -> PacketCapture:
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    return PacketCapture(enable_mqtt=False)
+
+
+
+def test_retryable_device_command_serialises(capture: PacketCapture):
+    """Overlapping device commands kill the BLE link; the wrapper must serialise."""
+    capture.connected = True
+    import types as _types
+    capture.meshcore = _types.SimpleNamespace(is_connected=True)
+    overlap = {"cur": 0, "max": 0}
+
+    async def slow_command():
+        overlap["cur"] += 1
+        overlap["max"] = max(overlap["max"], overlap["cur"])
+        await asyncio.sleep(0.01)
+        overlap["cur"] -= 1
+        return type("E", (), {"type": "ok", "payload": {}})()
+
+    async def scenario():
+        await asyncio.gather(*(
+            capture.retryable_device_command(slow_command, f"cmd{i}", timeout=5, max_retries=1)
+            for i in range(6)
+        ))
+
+    asyncio.run(scenario())
+    assert overlap["max"] == 1, f"{overlap['max']} device commands overlapped"
+
+
+def test_reentrant_lock_allows_same_task_to_nest():
+    """JWT signing holds the lock, then its fallback re-enters via
+    retryable_device_command. A plain asyncio.Lock deadlocks there."""
+    lock = pc_mod.TaskReentrantLock()
+
+    async def scenario():
+        async with lock:
+            async with lock:          # would hang on a plain Lock
+                assert lock.locked()
+            assert lock.locked()      # still held at depth 1
+        return lock.locked()
+
+    assert asyncio.run(asyncio.wait_for(scenario(), timeout=2.0)) is False
+
+
+def test_reentrant_lock_still_excludes_other_tasks():
+    """Re-entry is per task; concurrent tasks must still serialise."""
+    lock = pc_mod.TaskReentrantLock()
+    overlap = {"cur": 0, "max": 0}
+
+    async def worker():
+        async with lock:
+            overlap["cur"] += 1
+            overlap["max"] = max(overlap["max"], overlap["cur"])
+            await asyncio.sleep(0)
+            overlap["cur"] -= 1
+
+    async def scenario():
+        await asyncio.gather(*(worker() for _ in range(6)))
+
+    asyncio.run(scenario())
+    assert overlap["max"] == 1
+
+
+def test_reentrant_lock_releases_on_exception():
+    lock = pc_mod.TaskReentrantLock()
+
+    async def scenario():
+        try:
+            async with lock:
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        return lock.locked()
+
+    assert asyncio.run(scenario()) is False
+
+
+def test_retryable_device_command_gives_up_rather_than_queueing_forever(
+    capture: PacketCapture,
+):
+    """A stalled holder must not block the connection watchdog indefinitely.
+
+    The watchdog is the one thing that can recover a stalled link, and its own
+    timeout cannot fire while it is still queued for the lock.
+    """
+    capture.connected = True
+    import types as _types
+    capture.meshcore = _types.SimpleNamespace(is_connected=True)
+    capture.device_lock_wait_margin = 0.05
+
+    async def scenario():
+        await capture.device_command_lock.acquire()   # simulate a stalled holder
+
+        async def never():
+            return None
+
+        try:
+            return await asyncio.wait_for(
+                capture.retryable_device_command(never, "health", timeout=0.05, max_retries=1),
+                timeout=3.0,
+            )
+        finally:
+            capture.device_command_lock.release()
+
+    assert asyncio.run(scenario()) is None

--- a/tests/packet_capture/test_device_lock.py
+++ b/tests/packet_capture/test_device_lock.py
@@ -1,10 +1,15 @@
 """Serialisation of device commands.
 
-Two overlapping writes to the BLE RX characteristic drop the link outright
-("BLE write failed: 19", reproduced on hardware). Nothing in the app guaranteed
-callers were sequential -- schedulers, health checks, JWT signing and user
-commands all issue independently -- so device commands are funnelled through a
-single lock. It is task-reentrant because the JWT path legitimately nests.
+Nothing in the app guarantees callers are sequential -- schedulers, health
+checks, JWT signing and user commands all issue independently -- so device
+commands are funnelled through a single lock. It is task-reentrant because the
+JWT path legitimately nests.
+
+meshcore_py >= 2.3.8 serialises the BLE write itself, which is what stops two
+overlapping writes from dropping the link ("BLE write failed: 19", reproduced on
+hardware). This lock covers what that cannot: a command is a write *plus* a wait
+for its reply, which the library does not serialise, and multi-frame sequences
+like on-device JWT signing have to be held as a unit.
 """
 from __future__ import annotations
 
@@ -24,7 +29,7 @@ def capture(monkeypatch: pytest.MonkeyPatch) -> PacketCapture:
 
 
 def test_retryable_device_command_serialises(capture: PacketCapture):
-    """Overlapping device commands kill the BLE link; the wrapper must serialise."""
+    """Concurrent commands can take each other's reply; the wrapper must serialise."""
     capture.connected = True
     import types as _types
     capture.meshcore = _types.SimpleNamespace(is_connected=True)

--- a/tests/packet_capture/test_neighbors.py
+++ b/tests/packet_capture/test_neighbors.py
@@ -1,0 +1,1690 @@
+"""Tests for the MQTT neighbors feature (discovery, scopes, payload, gating)."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from meshcore_packet_capture import neighbors as nb
+
+
+# --------------------------------------------------------------------------
+# Interval clamping (firmware band: 12-336h, default 24h)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [(11, 12), (12, 12), (24, 24), (48, 48), (336, 336), (400, 336), (0, 24), (-5, 24)],
+)
+def test_clamp_interval_hours(given, expected):
+    assert nb.clamp_interval_hours(given) == expected
+
+
+def test_interval_seconds_uses_clamped_value():
+    assert nb.NeighborsConfig(interval_hours=1).interval_seconds == 12 * 3600
+    assert nb.NeighborsConfig(interval_hours=9999).interval_seconds == 336 * 3600
+
+
+# --------------------------------------------------------------------------
+# Ordering: most recently heard, then stronger SNR, then pubkey
+# --------------------------------------------------------------------------
+
+def _entry(pubkey_byte: str, snr: float, heard_at: float) -> nb.NeighborEntry:
+    return nb.NeighborEntry(pubkey=pubkey_byte * 64, snr=snr, heard_at=heard_at)
+
+
+def test_sort_prefers_most_recently_heard():
+    older = _entry("a", 20.0, 100.0)
+    newer = _entry("b", -5.0, 200.0)
+    assert nb.sort_entries([older, newer]) == [newer, older]
+
+
+def test_sort_breaks_recency_tie_by_snr():
+    weak = _entry("a", 1.0, 100.0)
+    strong = _entry("b", 9.0, 100.0)
+    assert nb.sort_entries([weak, strong]) == [strong, weak]
+
+
+def test_sort_breaks_full_tie_by_pubkey_ascending():
+    first = _entry("1", 5.0, 100.0)
+    second = _entry("2", 5.0, 100.0)
+    assert nb.sort_entries([second, first]) == [first, second]
+
+
+# --------------------------------------------------------------------------
+# Payload shape and tail-drop
+# --------------------------------------------------------------------------
+
+def test_message_matches_firmware_contract():
+    entry = nb.NeighborEntry(pubkey="ab" * 32, snr=9.75, heard_at=100.0, scopes="DEN,APRS")
+    entry.status = nb.STATUS_RESPONDED
+    message, dropped = nb.build_neighbors_message(
+        "MeshCore-HOWL", "A1B2", "DEN,APRS", [entry], timestamp="2024-01-01T12:00:00+00:00", now=142.0
+    )
+    assert dropped == 0
+    # Firmware key order (MQTTPayloadBuilder.cpp:200-210).
+    assert list(message.keys()) == [
+        "timestamp", "origin", "origin_id",
+        "total_neighbors", "queried_neighbors", "truncated",
+        "self", "neighbors",
+    ]
+    assert message["origin"] == "MeshCore-HOWL"
+    assert message["origin_id"] == "A1B2"
+    assert message["self"] == {"scopes": "DEN,APRS"}
+
+    assert message["total_neighbors"] == 1
+    assert message["queried_neighbors"] == 1
+    assert message["truncated"] is False
+
+    (published,) = message["neighbors"]
+    assert list(published.keys()) == ["pubkey", "snr", "heard_secs_ago", "scopes", "status"]
+    assert published["pubkey"] == ("ab" * 32).upper()
+    assert published["snr"] == 9.75
+    assert published["heard_secs_ago"] == 42
+    assert published["status"] == "responded"
+
+
+def test_heard_secs_ago_never_negative():
+    entry = nb.NeighborEntry(pubkey="cd" * 32, snr=0.0, heard_at=500.0)
+    # Clock stepped backwards between discovery and publish.
+    assert entry.heard_secs_ago(now=100.0) == 0
+
+
+def test_default_status_is_timeout():
+    assert nb.NeighborEntry(pubkey="ef" * 32, snr=0.0, heard_at=1.0).status == nb.STATUS_TIMEOUT
+
+
+def test_tail_is_dropped_at_budget_keeping_most_useful():
+    # Newest first: heard_at descending is the retention order.
+    entries = [
+        nb.NeighborEntry(pubkey=f"{i:02x}" * 32, snr=0.0, heard_at=float(i), scopes="X" * 40)
+        for i in range(40)
+    ]
+    message, dropped = nb.build_neighbors_message(
+        "o", "id", "", entries, timestamp="T", now=100.0, budget=1024
+    )
+    assert dropped > 0
+    assert len(message["neighbors"]) + dropped == len(entries)
+    assert len(json.dumps(message)) < 1024
+    # The retained entries are the highest heard_at values.
+    retained = {e["pubkey"].lower() for e in message["neighbors"]}
+    expected_first = (f"{39:02x}" * 32)
+    assert expected_first in retained
+
+
+def test_budget_not_applied_when_payload_fits():
+    entries = [nb.NeighborEntry(pubkey="11" * 32, snr=1.0, heard_at=1.0)]
+    message, dropped = nb.build_neighbors_message("o", "id", "", entries, timestamp="T", now=1.0)
+    assert dropped == 0
+    assert len(message["neighbors"]) == 1
+
+
+# --------------------------------------------------------------------------
+# Zero-hop contact override (the mechanism from plan section 3.1)
+# --------------------------------------------------------------------------
+
+class _FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def _record(self, msg, *a, **k):
+        self.messages.append(str(msg))
+
+    debug = info = warning = error = _record
+
+
+def test_zero_hop_contact_is_direct_with_empty_path():
+    contact = nb._zero_hop_contact("aa" * 32)
+    # out_path_len == 0 keeps meshcore_py off its out_path_len == -1 branch, so it
+    # issues no change_contact_path/reset_path writes to the device.
+    assert contact["out_path_len"] == 0
+    assert contact["out_path"] == ""
+    assert contact["public_key"] == "aa" * 32
+
+
+class _ContactCacheMeshCore:
+    """Mirrors MeshCore: `contacts` is a property returning the live dict."""
+
+    def __init__(self, initial=None):
+        self._contacts = dict(initial or {})
+
+    @property
+    def contacts(self):
+        return self._contacts
+
+
+def test_override_injects_then_removes_when_no_prior_contact():
+    mc = _ContactCacheMeshCore()
+    key = "bb" * 32
+    with nb.zero_hop_contact_override(mc, key, _FakeLogger()) as ok:
+        assert ok is True
+        assert mc._contacts[key]["out_path_len"] == 0
+    assert key not in mc._contacts
+
+
+def test_override_restores_preexisting_contact_exactly():
+    key = "cc" * 32
+    real = {"public_key": key, "out_path_len": 3, "out_path": "aabbcc", "adv_name": "repeater"}
+    mc = _ContactCacheMeshCore({key: real})
+    with nb.zero_hop_contact_override(mc, key, _FakeLogger()):
+        # A stale multi-hop path must not route the probe the long way.
+        assert mc._contacts[key]["out_path_len"] == 0
+    assert mc._contacts[key] is real
+    assert mc._contacts[key]["out_path_len"] == 3
+
+
+def test_override_restores_even_when_body_raises():
+    key = "dd" * 32
+    real = {"public_key": key, "out_path_len": 2, "out_path": "1122"}
+    mc = _ContactCacheMeshCore({key: real})
+    with pytest.raises(RuntimeError):
+        with nb.zero_hop_contact_override(mc, key, _FakeLogger()):
+            raise RuntimeError("scope request blew up")
+    assert mc._contacts[key] is real
+
+
+def test_override_reports_false_without_contact_cache():
+    class FakeMeshCore:
+        pass
+
+    with nb.zero_hop_contact_override(FakeMeshCore(), "ee" * 32, _FakeLogger()) as ok:
+        assert ok is False
+
+
+# --------------------------------------------------------------------------
+# Scope collection: pacing, status assignment, budget
+# --------------------------------------------------------------------------
+
+class _FakeCommands:
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    async def req_regions_sync(self, pubkey, timeout=0, min_timeout=0):
+        self.calls.append({"pubkey": pubkey, "timeout": timeout, "min_timeout": min_timeout})
+        result = self._responses.get(pubkey, None)
+        # The real function returns None for every device/library failure -- send()
+        # swallows exceptions into Event(ERROR) and req_regions_sync maps that to
+        # None. Only a genuine transport-level blow-up propagates, so exceptions
+        # here are opt-in per test rather than the default failure mode.
+        # BaseException, not Exception: CancelledError is not an Exception subclass.
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class _FakeMeshCore:
+    def __init__(self, responses):
+        self.commands = _FakeCommands(responses)
+        self._contacts: dict = {}
+
+    @property
+    def contacts(self):
+        return self._contacts
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def no_real_waiting(monkeypatch: pytest.MonkeyPatch):
+    """Collapse the discover window and settle gaps to a bare event-loop yield.
+
+    Yielding rather than skipping matters: EventDispatcher spawns async callbacks
+    as background tasks, so the collection path only works if control is handed
+    back to the loop.
+    """
+    real_sleep = asyncio.sleep
+
+    async def instant(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr(nb.asyncio, "sleep", instant)
+
+
+def test_collect_scopes_assigns_statuses():
+    responded = _entry("a", 5.0, 300.0)
+    timed_out = _entry("b", 5.0, 200.0)
+    entries = [responded, timed_out]
+
+    mc = _FakeMeshCore({responded.pubkey: "DEN,APRS", timed_out.pubkey: None})
+    cfg = nb.NeighborsConfig(scope_gap=0.0)
+    _run(nb.collect_scopes(mc, entries, cfg, _FakeLogger()))
+
+    assert (responded.status, responded.scopes) == (nb.STATUS_RESPONDED, "DEN,APRS")
+    # None covers a real timeout and a device-level rejection alike.
+    assert timed_out.status == nb.STATUS_TIMEOUT
+
+
+def test_collect_scopes_reports_send_failed_when_no_contact_cache():
+    """No contact cache means nothing was transmitted at all.
+
+    Reporting that as a timeout would assert on the topic that the neighbor was
+    asked and stayed silent, when in fact no frame ever left the radio.
+    """
+    class NoCacheMeshCore:
+        def __init__(self):
+            self.commands = _FakeCommands({})
+
+    entry = _entry("a", 5.0, 100.0)
+    mc = NoCacheMeshCore()
+    logger = _FakeLogger()
+    _run(nb.collect_scopes(mc, [entry], nb.NeighborsConfig(scope_gap=0.0), logger))
+
+    assert entry.status == nb.STATUS_SEND_FAILED
+    assert mc.commands.calls == []
+    assert any("contact cache unavailable" in m for m in logger.messages)
+
+
+def test_collect_scopes_reports_send_failed_on_transport_exception():
+    entry = _entry("a", 5.0, 100.0)
+    mc = _FakeMeshCore({entry.pubkey: RuntimeError("serial write blew up")})
+    _run(nb.collect_scopes(mc, [entry], nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
+    assert entry.status == nb.STATUS_SEND_FAILED
+
+
+def test_collect_scopes_responded_with_empty_scope_string():
+    entry = _entry("a", 1.0, 100.0)
+    mc = _FakeMeshCore({entry.pubkey: ""})
+    _run(nb.collect_scopes(mc, [entry], nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
+    # An empty reply still means the neighbor answered - it just has no scopes.
+    assert entry.status == nb.STATUS_RESPONDED
+    assert entry.scopes == ""
+
+
+def test_collect_scopes_passes_auto_timeout_and_floor():
+    entry = _entry("a", 1.0, 100.0)
+    mc = _FakeMeshCore({entry.pubkey: "X"})
+    cfg = nb.NeighborsConfig(scope_gap=0.0, scope_timeout=0.0, scope_min_timeout=8.0)
+    _run(nb.collect_scopes(mc, [entry], cfg, _FakeLogger()))
+    # timeout=0 lets the device's own suggested_timeout drive the wait.
+    assert mc.commands.calls[0]["timeout"] == 0
+    assert mc.commands.calls[0]["min_timeout"] == 8.0
+
+
+def test_collect_scopes_honours_explicit_timeout_override():
+    entry = _entry("a", 1.0, 100.0)
+    mc = _FakeMeshCore({entry.pubkey: "X"})
+    cfg = nb.NeighborsConfig(scope_gap=0.0, scope_timeout=25.0)
+    _run(nb.collect_scopes(mc, [entry], cfg, _FakeLogger()))
+    assert mc.commands.calls[0]["timeout"] == 25.0
+
+
+def test_collect_scopes_queries_one_at_a_time_in_sorted_order():
+    entries = nb.sort_entries([_entry("a", 1.0, 100.0), _entry("b", 1.0, 300.0)])
+    mc = _FakeMeshCore({e.pubkey: "S" for e in entries})
+    _run(nb.collect_scopes(mc, entries, nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
+    # Newest-heard neighbor is queried first, so a truncated cycle covers it.
+    assert [c["pubkey"] for c in mc.commands.calls] == [entries[0].pubkey, entries[1].pubkey]
+
+
+def test_collect_scopes_stops_at_cycle_budget_leaving_rest_as_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    entries = [_entry(f"{i}", 1.0, float(100 - i)) for i in range(4)]
+    mc = _FakeMeshCore({e.pubkey: "S" for e in entries})
+    cfg = nb.NeighborsConfig(scope_gap=0.0, cycle_timeout=30.0)
+
+    # Jump the clock past the budget after the second neighbor is queried.
+    clock = {"t": 1000.0}
+    real_sync = mc.commands.req_regions_sync
+
+    async def ticking_sync(pubkey, timeout=0, min_timeout=0):
+        result = await real_sync(pubkey, timeout=timeout, min_timeout=min_timeout)
+        if len(mc.commands.calls) == 2:
+            clock["t"] += cfg.cycle_timeout + 1
+        return result
+
+    mc.commands.req_regions_sync = ticking_sync
+    monkeypatch.setattr(nb.time, "time", lambda: clock["t"])
+
+    logger = _FakeLogger()
+    _run(nb.collect_scopes(mc, entries, cfg, logger))
+
+    assert len(mc.commands.calls) == 2
+    # The two that were reached answered; the rest keep the firmware's fallback.
+    assert [e.status for e in entries[:2]] == [nb.STATUS_RESPONDED, nb.STATUS_RESPONDED]
+    assert [e.status for e in entries[2:]] == [nb.STATUS_TIMEOUT, nb.STATUS_TIMEOUT]
+    assert any("cycle budget" in m and "2 of 4" in m for m in logger.messages)
+
+
+def test_collect_scopes_handles_empty_list():
+    mc = _FakeMeshCore({})
+    _run(nb.collect_scopes(mc, [], nb.NeighborsConfig(), _FakeLogger()))
+    assert mc.commands.calls == []
+
+
+def test_collect_scopes_leaves_contact_cache_clean():
+    entries = [_entry("a", 1.0, 100.0), _entry("b", 1.0, 90.0)]
+    mc = _FakeMeshCore({entries[0].pubkey: "S", entries[1].pubkey: RuntimeError("boom")})
+    _run(nb.collect_scopes(mc, entries, nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
+    assert mc._contacts == {}
+
+
+def test_collect_scopes_propagates_cancellation():
+    entry = _entry("a", 1.0, 100.0)
+    mc = _FakeMeshCore({entry.pubkey: asyncio.CancelledError()})
+    with pytest.raises(asyncio.CancelledError):
+        _run(nb.collect_scopes(mc, [entry], nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
+
+
+# --------------------------------------------------------------------------
+# Self scopes
+# --------------------------------------------------------------------------
+
+def test_self_scopes_override_wins_without_querying():
+    class Commands:
+        async def get_default_flood_scope(self):
+            raise AssertionError("must not query when overridden")
+
+    class MC:
+        commands = Commands()
+
+    cfg = nb.NeighborsConfig(self_scopes="DEN,APRS")
+    assert _run(nb.fetch_self_scopes(MC(), cfg, _FakeLogger())) == "DEN,APRS"
+
+
+def test_self_scopes_absent_command_returns_empty():
+    class MC:
+        class commands:
+            pass
+
+    assert _run(nb.fetch_self_scopes(MC(), nb.NeighborsConfig(), _FakeLogger())) == ""
+
+
+# --------------------------------------------------------------------------
+# Discovery filter constants match the firmware
+# --------------------------------------------------------------------------
+
+def test_discover_filter_is_repeater_bitmask():
+    # sendNodeDiscoverReq: data[1] = (1 << ADV_TYPE_REPEATER)
+    assert nb.ADV_TYPE_REPEATER == 0x02
+    assert nb.DISCOVER_FILTER_REPEATER == 0x04
+
+
+def test_json_budget_matches_firmware_buffer():
+    # MQTTBridge::NEIGHBORS_JSON_BUFFER_SIZE
+    assert nb.NEIGHBORS_JSON_BUDGET == 10240
+
+
+# --------------------------------------------------------------------------
+# Stage 1: discovery response collection and filtering
+# --------------------------------------------------------------------------
+
+class _FakeEvent:
+    def __init__(self, etype, payload):
+        self.type = etype
+        self.payload = payload
+
+
+# Sentinels for "tag matching this discovery round"; the fake fills in the real one,
+# in lowercase hex or uppercase hex respectively.
+ROUND_TAG = object()
+ROUND_TAG_UPPER = object()
+
+
+def _resp(pubkey: str, snr: float, tag=ROUND_TAG, node_type: int = 0x02) -> dict:
+    return {"pubkey": pubkey, "SNR": snr, "node_type": node_type, "tag": tag}
+
+
+class _DiscoverMeshCore:
+    """Replays DISCOVER_RESPONSE events into the handler during the window."""
+
+    def __init__(self, responses, *, send_error=False):
+        self._responses = responses
+        self._send_error = send_error
+        self.unsubscribed = []
+        self.sent = None
+        self._handler = None
+        outer = self
+
+        class Commands:
+            async def send_node_discover_req(self, filter, prefix_only=True, tag=None, since=None):
+                outer.sent = {"filter": filter, "prefix_only": prefix_only, "tag": tag}
+                # The caller must know the tag before subscribing, otherwise a
+                # response arriving here would dodge the tag check.
+                assert tag is not None, "caller must supply the tag"
+                if outer._send_error:
+                    return _FakeEvent("ERROR", {"reason": "unsupported"})
+                round_tag = tag.to_bytes(4, "little").hex()
+                for payload in outer._responses:
+                    event = dict(payload)
+                    if event["tag"] is ROUND_TAG:
+                        event["tag"] = round_tag
+                    elif event["tag"] is ROUND_TAG_UPPER:
+                        event["tag"] = round_tag.upper()
+                    else:
+                        event["tag"] = int(event["tag"]).to_bytes(4, "little").hex()
+                    await outer._handler(_FakeEvent("discover_response", event))
+                return _FakeEvent("OK", {"tag": tag})
+
+        self.commands = Commands()
+
+    def subscribe(self, event_type, handler):
+        self._handler = handler
+        return f"sub:{event_type}"
+
+    def unsubscribe(self, subscription):
+        self.unsubscribed.append(subscription)
+
+
+def test_discover_requests_full_pubkeys_from_repeaters_only():
+    mc = _DiscoverMeshCore([])
+    _run(nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger()))
+    # sendNodeDiscoverReq: filter = 1 << ADV_TYPE_REPEATER, prefix_only = 0
+    assert mc.sent["filter"] == nb.DISCOVER_FILTER_REPEATER
+    assert mc.sent["prefix_only"] is False
+
+
+def test_discover_supplies_its_own_tag():
+    mc = _DiscoverMeshCore([])
+    _run(nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger()))
+    # A caller-generated tag is what closes the subscribe/send race.
+    assert isinstance(mc.sent["tag"], int)
+    assert 1 <= mc.sent["tag"] <= 0xFFFFFFFF
+
+
+def test_discover_collects_matching_responses():
+    a, b = "aa" * 32, "bb" * 32
+    mc = _DiscoverMeshCore([_resp(a, 5.0), _resp(b, 9.0)])
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    )
+    assert {e.pubkey for e in entries} == {a, b}
+
+
+def test_discover_filters_non_repeaters_short_keys_self_and_wrong_tag():
+    good = "aa" * 32
+    self_key = "bb" * 32
+    mc = _DiscoverMeshCore([
+        _resp(good, 5.0),
+        _resp("cc" * 32, 5.0, node_type=0x01),      # companion, not a repeater
+        _resp("dd" * 8, 5.0),                       # 8-byte prefix, not a full pubkey
+        _resp(self_key, 5.0),                       # ourselves
+        _resp("ee" * 32, 5.0, tag=0x99999999),      # a different discovery round
+    ])
+    entries = _run(
+        nb.discover_neighbors(
+            mc, nb.NeighborsConfig(discover_window=0.0), self_key.upper(), _FakeLogger()
+        )
+    )
+    assert [e.pubkey for e in entries] == [good]
+
+
+def test_discover_normalises_pubkey_case():
+    key = "AB" * 32
+    mc = _DiscoverMeshCore([_resp(key, 5.0)])
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    )
+    # Pubkeys are normalised to lowercase for consistent comparison/dedupe.
+    assert [e.pubkey for e in entries] == [key.lower()]
+
+
+def test_discover_matches_tag_case_insensitively():
+    key = "aa" * 32
+    mc = _DiscoverMeshCore([_resp(key, 5.0, tag=ROUND_TAG_UPPER)])
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    )
+    assert [e.pubkey for e in entries] == [key]
+
+
+def test_discover_dedupes_across_pubkey_case():
+    key = "aa" * 32
+    mc = _DiscoverMeshCore([_resp(key, 3.0), _resp(key.upper(), 11.0)])
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    )
+    assert len(entries) == 1
+    assert entries[0].snr == 11.0
+
+
+def test_discover_dedupes_keeping_strongest_snr():
+    key = "aa" * 32
+    mc = _DiscoverMeshCore([_resp(key, 3.0), _resp(key, 11.0), _resp(key, 7.0)])
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    )
+    assert len(entries) == 1
+    assert entries[0].snr == 11.0
+
+
+def test_discover_returns_sorted_entries():
+    mc = _DiscoverMeshCore([_resp("aa" * 32, 1.0), _resp("bb" * 32, 20.0)])
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    )
+    assert entries == nb.sort_entries(entries)
+
+
+def test_discover_returns_none_when_request_rejected():
+    mc = _DiscoverMeshCore([], send_error=True)
+    assert _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    ) is None
+
+
+def test_discover_always_unsubscribes():
+    mc = _DiscoverMeshCore([], send_error=True)
+    _run(nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger()))
+    # The handler is per-run; leaving it attached would leak across reconnects.
+    assert mc.unsubscribed == ["sub:discover_response"]
+
+
+def test_discover_empty_result_is_empty_list_not_none():
+    mc = _DiscoverMeshCore([])
+    assert _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(discover_window=0.0), None, _FakeLogger())
+    ) == []
+
+
+# --------------------------------------------------------------------------
+# PacketCapture integration: topic resolution, per-broker gating, scheduling
+# --------------------------------------------------------------------------
+
+from meshcore_packet_capture import packet_capture as pc_mod  # noqa: E402
+from meshcore_packet_capture.packet_capture import PacketCapture  # noqa: E402
+
+
+@pytest.fixture
+def capture(monkeypatch: pytest.MonkeyPatch) -> PacketCapture:
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    cap = PacketCapture(enable_mqtt=False)
+    cap.device_public_key = "ab" * 32
+    cap.device_name = "MeshCore-TEST"
+    return cap
+
+
+def test_neighbors_topic_defaults_to_iata_route(capture: PacketCapture):
+    assert capture.get_topic("neighbors", 1) == f"meshcore/SEA/{('ab' * 32)}/neighbors"
+
+
+def test_neighbors_topic_none_without_iata(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "LOC")  # the unconfigured default
+    cap = PacketCapture(enable_mqtt=False)
+    cap.device_public_key = "ab" * 32
+    # No classic meshcore/neighbors fallback: the firmware only routes this topic
+    # on MeshCore-style topics, which require an IATA.
+    assert cap.get_topic("neighbors", 1) is None
+
+
+def test_neighbors_topic_explicit_override_works_without_iata(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "LOC")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_TOPIC_NEIGHBORS", "custom/{PUBLIC_KEY}/neighbors")
+    cap = PacketCapture(enable_mqtt=False)
+    cap.device_public_key = "ab" * 32
+    assert cap.get_topic("neighbors", 1) == f"custom/{('ab' * 32)}/neighbors"
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("true", True), ("True", True), ("1", True), ("yes", True), ("on", True),
+    ("false", False), ("0", False), ("off", False), ("", False),
+])
+def test_broker_wants_neighbors_parsing(monkeypatch: pytest.MonkeyPatch, value, expected):
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", value)
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap._broker_wants_neighbors(1) is expected
+
+
+def test_broker_wants_neighbors_defaults_off(capture: PacketCapture):
+    # Unset must be off, matching the firmware's mqtt_neighbors_enabled default.
+    assert capture._broker_wants_neighbors(1) is False
+
+
+def test_neighbors_broker_nums_requires_enabled_and_opted_in(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_ENABLED", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT2_ENABLED", "true")   # enabled, not opted in
+    monkeypatch.setenv("PACKETCAPTURE_MQTT3_ENABLED", "false")  # opted in but disabled
+    monkeypatch.setenv("PACKETCAPTURE_MQTT3_NEIGHBORS", "true")
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap.neighbors_broker_nums() == [1]
+
+
+def test_neighbors_broker_nums_empty_when_none_opted_in(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_ENABLED", "true")
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap.neighbors_broker_nums() == []
+
+
+def test_safe_publish_skips_brokers_that_did_not_opt_in(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    # broker 2 deliberately left off
+    cap = PacketCapture(enable_mqtt=True)
+    cap.device_public_key = "ab" * 32
+    cap.mqtt_connected = True
+
+    published = []
+
+    class FakeClient:
+        def __init__(self, num):
+            self.num = num
+
+        def is_connected(self):
+            return True
+
+        def publish(self, topic, payload, qos=0, retain=False):
+            published.append((self.num, topic, retain))
+            return type("R", (), {"rc": 0})()
+
+    cap.mqtt_clients = [
+        {"client": FakeClient(1), "broker_num": 1, "label": "one"},
+        {"client": FakeClient(2), "broker_num": 2, "label": "two"},
+    ]
+
+    metrics = cap.safe_publish(None, "{}", retain=False, topic_type="neighbors")
+    assert [p[0] for p in published] == [1]
+    assert metrics == {"attempted": 1, "succeeded": 1}
+
+
+def test_safe_publish_neighbors_is_not_retained(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    cap = PacketCapture(enable_mqtt=True)
+    cap.device_public_key = "ab" * 32
+    cap.mqtt_connected = True
+
+    seen = {}
+
+    class FakeClient:
+        def is_connected(self):
+            return True
+
+        def publish(self, topic, payload, qos=0, retain=False):
+            seen.update({"topic": topic, "retain": retain, "qos": qos})
+            return type("R", (), {"rc": 0})()
+
+    cap.mqtt_clients = [{"client": FakeClient(), "broker_num": 1, "label": "one"}]
+    cap.safe_publish(None, "{}", retain=False, topic_type="neighbors")
+    assert seen["retain"] is False
+    assert seen["topic"].endswith("/neighbors")
+
+
+def test_neighbors_state_roundtrip_preserves_advert_time(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_DATA_DIR", str(tmp_path))
+    cap = PacketCapture(enable_mqtt=False)
+
+    import time as _time
+    now = _time.time()
+    cap.last_advert_time = now - 100
+    cap._save_advert_state()
+    cap.last_neighbors_publish = now - 50
+    cap._save_neighbors_state()
+
+    # Saving one key must not clobber the other: both live in advert_state.json.
+    reloaded = PacketCapture(enable_mqtt=False)
+    assert reloaded.last_advert_time == pytest.approx(now - 100)
+    assert reloaded.last_neighbors_publish == pytest.approx(now - 50)
+
+
+def test_neighbors_state_rejects_future_timestamp(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_DATA_DIR", str(tmp_path))
+    cap = PacketCapture(enable_mqtt=False)
+    import time as _time
+    cap.last_neighbors_publish = _time.time() + 86400
+    cap._save_neighbors_state()
+    # A future stamp would suppress publishing indefinitely, so it is discarded.
+    assert PacketCapture(enable_mqtt=False).last_neighbors_publish == 0
+
+
+def test_neighbors_config_reads_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_NEIGHBORS_INTERVAL_HOURS", "400")  # above the band
+    monkeypatch.setenv("PACKETCAPTURE_NEIGHBORS_SCOPE_GAP", "3.5")
+    monkeypatch.setenv("PACKETCAPTURE_NEIGHBORS_MAX", "8")
+    monkeypatch.setenv("PACKETCAPTURE_NEIGHBORS_SELF_SCOPES", " DEN,APRS ")
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap.neighbors_config.interval_hours == 336
+    assert cap.neighbors_config.scope_gap == 3.5
+    assert cap.neighbors_config.max_neighbors == 8
+    assert cap.neighbors_config.self_scopes == "DEN,APRS"
+
+
+def test_neighbors_commands_available_detection(capture: PacketCapture):
+    import types as _types
+    capture.meshcore = _types.SimpleNamespace(commands=_types.SimpleNamespace())
+    assert capture.neighbors_commands_available() is False
+
+    capture.meshcore = _types.SimpleNamespace(commands=_types.SimpleNamespace(
+        send_node_discover_req=lambda *a, **k: None,
+        req_regions_sync=lambda *a, **k: None,
+    ))
+    assert capture.neighbors_commands_available() is True
+
+
+def test_neighbors_cycle_skips_when_no_broker_opted_in(capture: PacketCapture):
+    capture.enable_mqtt = True
+    capture.mqtt_connected = True
+    capture.connected = True
+    import types as _types
+    capture.meshcore = _types.SimpleNamespace(is_connected=True, commands=_types.SimpleNamespace(
+        send_node_discover_req=lambda *a, **k: None,
+        req_regions_sync=lambda *a, **k: None,
+    ))
+    assert _run(capture.run_neighbors_cycle()) is False
+
+
+def test_sort_uses_published_seconds_so_snr_breaks_ties():
+    # Both publish heard_secs_ago = 0 at now=101.0, so SNR must decide rather
+    # than the sub-second clock difference.
+    weak_later = nb.NeighborEntry(pubkey="aa" * 32, snr=1.0, heard_at=100.9)
+    strong_earlier = nb.NeighborEntry(pubkey="bb" * 32, snr=9.0, heard_at=100.1)
+    ordered = nb.sort_entries([weak_later, strong_earlier], now=101.0)
+    assert ordered == [strong_earlier, weak_later]
+
+
+def test_published_order_is_monotonic_in_heard_secs_ago():
+    """Ordering must match the field actually published, not the raw clock.
+
+    Quantising differently from heard_secs_ago let the payload come out
+    non-monotonic in its own sort key.
+    """
+    entries = [
+        nb.NeighborEntry(pubkey="aa" * 32, snr=9.0, heard_at=100.00),
+        nb.NeighborEntry(pubkey="bb" * 32, snr=1.0, heard_at=100.99),
+    ]
+    message, _ = nb.build_neighbors_message(
+        "o", "id", "", entries, timestamp="T", now=101.5
+    )
+    ages = [e["heard_secs_ago"] for e in message["neighbors"]]
+    assert ages == sorted(ages), f"published order not monotonic: {ages}"
+
+
+def test_sort_still_prefers_a_genuinely_later_second():
+    older_strong = nb.NeighborEntry(pubkey="aa" * 32, snr=20.0, heard_at=100.0)
+    newer_weak = nb.NeighborEntry(pubkey="bb" * 32, snr=-5.0, heard_at=102.0)
+    assert nb.sort_entries([older_strong, newer_weak]) == [newer_weak, older_strong]
+
+
+# --------------------------------------------------------------------------
+# Discovery against real EventDispatcher semantics
+# --------------------------------------------------------------------------
+
+def test_discover_collects_through_real_event_dispatcher():
+    """Collection must work when callbacks are spawned as background tasks.
+
+    The hand-rolled fake invokes the handler inline, which would hide a failure
+    to yield control to the loop. This drives a dispatcher that behaves like the
+    library's: queue the event, then run the callback as a separate task.
+    """
+    class SpawningDispatcher:
+        def __init__(self):
+            self._subs = {}
+            self._tasks = []
+
+        def subscribe(self, event_type, handler):
+            self._subs[event_type] = handler
+            return event_type
+
+        def unsubscribe(self, sub):
+            self._subs.pop(sub, None)
+
+        def emit(self, event):
+            handler = self._subs.get(event.type)
+            if handler is not None:
+                self._tasks.append(asyncio.create_task(handler(event)))
+
+    class MC:
+        def __init__(self):
+            self.dispatcher = SpawningDispatcher()
+            outer = self
+
+            class Commands:
+                async def send_node_discover_req(s, filter, prefix_only=True, tag=None, since=None):
+                    th = tag.to_bytes(4, "little").hex()
+                    for pk, snr in (("aa" * 32, 5.0), ("bb" * 32, 9.0)):
+                        outer.dispatcher.emit(_FakeEvent(
+                            "discover_response",
+                            {"pubkey": pk, "SNR": snr, "node_type": 2, "tag": th},
+                        ))
+                    return _FakeEvent("OK", {"tag": tag})
+
+            self.commands = Commands()
+
+        def subscribe(self, et, handler):
+            return self.dispatcher.subscribe(et, handler)
+
+        def unsubscribe(self, sub):
+            self.dispatcher.unsubscribe(sub)
+
+    mc = MC()
+    entries = _run(
+        nb.discover_neighbors(mc, nb.NeighborsConfig(), None, _FakeLogger())
+    )
+    assert {e.pubkey for e in entries} == {"aa" * 32, "bb" * 32}
+
+
+def test_discover_ignores_responses_arriving_after_the_window():
+    """A straggler must not mutate entries already snapshotted and returned."""
+    captured = {}
+
+    class MC:
+        def __init__(self):
+            outer = self
+
+            class Commands:
+                async def send_node_discover_req(s, filter, prefix_only=True, tag=None, since=None):
+                    th = tag.to_bytes(4, "little").hex()
+                    await outer.handler(_FakeEvent(
+                        "discover_response",
+                        {"pubkey": "aa" * 32, "SNR": 5.0, "node_type": 2, "tag": th},
+                    ))
+                    captured["tag"] = th
+                    return _FakeEvent("OK", {"tag": tag})
+
+            self.commands = Commands()
+
+        def subscribe(self, et, handler):
+            self.handler = handler
+            return "sub"
+
+        def unsubscribe(self, sub):
+            pass  # deliberately leave the handler reachable
+
+    async def scenario():
+        mc = MC()
+        entries = await nb.discover_neighbors(mc, nb.NeighborsConfig(), None, _FakeLogger())
+        # A late event for a pubkey ALREADY collected: without the latch this
+        # mutates the very NeighborEntry we just returned. Asserting on a new
+        # pubkey instead would prove nothing, since sort_entries returns a copy.
+        await mc.handler(_FakeEvent(
+            "discover_response",
+            {"pubkey": "aa" * 32, "SNR": 30.0, "node_type": 2, "tag": captured["tag"]},
+        ))
+        return entries
+
+    entries = _run(scenario())
+    assert [e.pubkey for e in entries] == ["aa" * 32]
+    assert entries[0].snr == 5.0, "a straggler mutated an already-returned entry"
+
+
+# --------------------------------------------------------------------------
+# Unroutable brokers must not trigger on-air work
+# --------------------------------------------------------------------------
+
+def test_neighbors_broker_nums_excludes_broker_with_unresolvable_topic(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Opted in but no IATA and no override: the topic can never resolve.
+
+    Including it would spend a discover window plus one on-air scope request per
+    neighbor every cycle and then throw the result away.
+    """
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "LOC")  # the unconfigured default
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_ENABLED", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    cap = PacketCapture(enable_mqtt=False)
+    cap.device_public_key = "ab" * 32
+
+    assert cap.neighbors_broker_nums() == []
+
+    logged = []
+    cap.logger = type("L", (), {
+        "warning": lambda _s, m: logged.append(m),
+        "info": lambda _s, m: None,
+        "debug": lambda _s, m: None,
+        "error": lambda _s, m, **k: None,
+    })()
+    assert cap.neighbors_broker_nums(warn_unroutable=True) == []
+    assert any("no neighbors topic could be resolved" in m for m in logged)
+
+
+def test_neighbors_broker_nums_keeps_broker_with_explicit_topic(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "LOC")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_ENABLED", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_TOPIC_NEIGHBORS", "custom/n")
+    cap = PacketCapture(enable_mqtt=False)
+    cap.device_public_key = "ab" * 32
+    assert cap.neighbors_broker_nums() == [1]
+
+
+def test_broker_requires_iata_considers_neighbors_topic(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_TOPIC_NEIGHBORS", "x/{IATA}/{PUBLIC_KEY}/neighbors")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    cap = PacketCapture(enable_mqtt=False)
+    # For a broker that opted in, an IATA-templated neighbors topic must count,
+    # or it silently publishes to the literal default.
+    assert cap.broker_requires_iata(1) is True
+
+
+def test_neighbors_topic_does_not_disable_a_broker_that_opted_out(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A global [topics] neighbors template must not disable unrelated brokers.
+
+    broker_requires_iata() gates whether a broker connects at all, so counting
+    NEIGHBORS unconditionally would stop a plain local broker from publishing
+    packets and status just because a neighbors template exists somewhere.
+    """
+    monkeypatch.setenv("PACKETCAPTURE_TOPIC_NEIGHBORS", "meshcore/{IATA}/{PUBLIC_KEY}/neighbors")
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap._broker_wants_neighbors(1) is False
+    assert cap.broker_requires_iata(1) is False
+
+
+# --------------------------------------------------------------------------
+# Config validation floors
+# --------------------------------------------------------------------------
+
+def test_config_floors_reject_values_that_collect_nothing():
+    cfg = nb.NeighborsConfig(discover_window=0.0, max_neighbors=0, cycle_timeout=0.0, scope_gap=-1)
+    assert cfg.discover_window == nb.MIN_DISCOVER_WINDOW
+    assert cfg.max_neighbors == 1
+    assert cfg.cycle_timeout == nb.MIN_CYCLE_TIMEOUT
+    assert cfg.scope_gap == 0.0
+
+
+def test_out_of_band_interval_is_warned_not_silently_clamped(monkeypatch: pytest.MonkeyPatch):
+    import logging
+    monkeypatch.setenv("PACKETCAPTURE_NEIGHBORS_INTERVAL_HOURS", "1")
+    warnings = []
+    # The warning fires inside __init__, before an instance logger can be patched.
+    monkeypatch.setattr(
+        logging.Logger, "warning", lambda self, msg, *a, **k: warnings.append(str(msg))
+    )
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap.neighbors_config.interval_hours == 12
+    assert any("outside the supported 12-336h range" in m for m in warnings)
+
+
+# --------------------------------------------------------------------------
+# run_neighbors_cycle happy path and scheduler
+# --------------------------------------------------------------------------
+
+class _CycleMeshCore:
+    is_connected = True
+
+    def __init__(self, scopes):
+        self._contacts = {}
+        outer = self
+
+        class Commands:
+            async def send_node_discover_req(s, filter, prefix_only=True, tag=None, since=None):
+                th = tag.to_bytes(4, "little").hex()
+                for pk in scopes:
+                    await outer.handler(_FakeEvent(
+                        "discover_response",
+                        {"pubkey": pk, "SNR": 5.0, "node_type": 2, "tag": th},
+                    ))
+                return _FakeEvent("OK", {"tag": tag})
+
+            async def req_regions_sync(s, pubkey, timeout=0, min_timeout=0):
+                assert outer._contacts[pubkey]["out_path_len"] == 0
+                return scopes[pubkey]
+
+            async def get_default_flood_scope(s):
+                return _FakeEvent("default_flood_scope", {"scope_name": "SEATTLE"})
+
+        self.commands = Commands()
+
+    @property
+    def contacts(self):
+        return self._contacts
+
+    def subscribe(self, et, handler):
+        self.handler = handler
+        return "sub"
+
+    def unsubscribe(self, sub):
+        pass
+
+
+def _cycle_capture(monkeypatch: pytest.MonkeyPatch, tmp_path, scopes):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_ENABLED", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_NEIGHBORS", "true")
+    monkeypatch.setenv("PACKETCAPTURE_DATA_DIR", str(tmp_path))
+    cap = PacketCapture(enable_mqtt=True)
+    cap.connected = True
+    cap.mqtt_connected = True
+    cap.device_public_key = "ff" * 32
+    cap.device_name = "MeshCore-CYCLE"
+    cap.meshcore = _CycleMeshCore(scopes)
+    return cap
+
+
+def test_run_neighbors_cycle_publishes_and_persists(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    scopes = {"aa" * 32: "DEN,APRS", "bb" * 32: None}
+    cap = _cycle_capture(monkeypatch, tmp_path, scopes)
+
+    calls = []
+    cap.safe_publish = lambda topic, payload, retain=False, **kw: (
+        calls.append({"payload": payload, "retain": retain, "kw": kw})
+        or {"attempted": 1, "succeeded": 1}
+    )
+
+    assert _run(cap.run_neighbors_cycle()) is True
+    assert len(calls) == 1
+    assert calls[0]["kw"]["topic_type"] == "neighbors"
+    assert calls[0]["retain"] is False
+
+    msg = json.loads(calls[0]["payload"])
+    assert msg["origin"] == "MeshCore-CYCLE"
+    assert msg["origin_id"] == ("ff" * 32).upper()
+    assert msg["self"]["scopes"] == "SEATTLE"
+    statuses = {e["pubkey"].lower(): e["status"] for e in msg["neighbors"]}
+    assert statuses == {"aa" * 32: "responded", "bb" * 32: "timeout"}
+
+    # Contact cache clean and the schedule advanced.
+    assert cap.meshcore.contacts == {}
+    assert cap.last_neighbors_publish > 0
+    assert PacketCapture(enable_mqtt=False).last_neighbors_publish == pytest.approx(
+        cap.last_neighbors_publish
+    )
+
+
+def test_run_neighbors_cycle_warns_when_no_broker_accepts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    cap = _cycle_capture(monkeypatch, tmp_path, {"aa" * 32: "DEN"})
+    cap.safe_publish = lambda *a, **k: {"attempted": 0, "succeeded": 0}
+    logged = []
+    monkeypatch.setattr(cap.logger, "warning", lambda m: logged.append(m))
+
+    assert _run(cap.run_neighbors_cycle()) is False
+    # Discovery cost airtime, so a silent no-op must not look like success.
+    assert any("no broker accepted the publish" in m for m in logged)
+
+
+def test_run_neighbors_cycle_warns_once_on_repeated_discover_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+
+    async def failing(*a, **k):
+        return _FakeEvent("ERROR", {"reason": "unsupported"})
+
+    cap.meshcore.commands.send_node_discover_req = failing
+    warnings = []
+    monkeypatch.setattr(cap.logger, "warning", lambda m: warnings.append(m))
+
+    for _ in range(4):
+        assert _run(cap.run_neighbors_cycle()) is False
+
+    # An unsupported build fails every cycle; ~288 warnings/day is noise.
+    assert len(warnings) == 1
+    assert cap.neighbors_discover_failures == 4
+
+
+def test_neighbors_scheduler_waits_then_runs_then_exits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.last_neighbors_publish = 0  # due immediately
+    ran = []
+
+    async def fake_cycle():
+        ran.append(1)
+        cap.last_neighbors_publish = 12345.0  # stamp, as the real one does
+        cap.should_exit = True
+        return True
+
+    cap.run_neighbors_cycle = fake_cycle
+    waits = []
+
+    async def fake_wait(seconds):
+        waits.append(seconds)
+        return cap.should_exit
+
+    cap.wait_with_shutdown = fake_wait
+    _run(cap.neighbors_scheduler())
+    assert ran == [1]
+
+
+def test_neighbors_scheduler_sleeps_when_not_yet_due(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    import time as _time
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.last_neighbors_publish = _time.time()  # just published
+    ran = []
+    cap.run_neighbors_cycle = lambda: ran.append(1)
+
+    waits = []
+
+    async def fake_wait(seconds):
+        waits.append(seconds)
+        cap.should_exit = True   # break out after the first sleep
+        return True
+
+    cap.wait_with_shutdown = fake_wait
+    _run(cap.neighbors_scheduler())
+
+    assert ran == []
+    # Sleeps the remaining interval, not a busy-loop tick.
+    assert waits and waits[0] > cap.neighbors_config.interval_seconds - 60
+
+
+def test_neighbors_scheduler_backs_off_when_cycle_cannot_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.last_neighbors_publish = 0  # due
+    attempts = []
+
+    async def bailing_cycle():
+        attempts.append(1)   # returns without stamping, as early exits do
+        return False
+
+    cap.run_neighbors_cycle = bailing_cycle
+    waits = []
+
+    async def fake_wait(seconds):
+        waits.append(seconds)
+        cap.should_exit = True
+        return True
+
+    cap.wait_with_shutdown = fake_wait
+    _run(cap.neighbors_scheduler())
+
+    # One attempt, then a bounded backoff instead of spinning on the due check.
+    assert attempts == [1]
+    assert waits == [300]
+
+
+def test_neighbors_scheduler_survives_cycle_exception(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.last_neighbors_publish = 0
+
+    async def boom():
+        raise RuntimeError("device vanished mid-cycle")
+
+    cap.run_neighbors_cycle = boom
+    waits = []
+
+    async def fake_wait(seconds):
+        waits.append(seconds)
+        cap.should_exit = True
+        return True
+
+    cap.wait_with_shutdown = fake_wait
+    _run(cap.neighbors_scheduler())   # must not propagate
+    assert waits == [300]
+
+
+# --------------------------------------------------------------------------
+# Manual trigger (--neighbors-now)
+# --------------------------------------------------------------------------
+
+def test_manual_trigger_defaults_off(capture: PacketCapture):
+    assert capture.neighbors_run_now is False
+    assert capture.neighbors_exit_after_run is False
+
+
+def test_manual_trigger_runs_cycle_and_can_exit(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.neighbors_run_now = True
+    cap.neighbors_exit_after_run = True
+    ran = []
+
+    async def fake_cycle():
+        ran.append(1)
+        return True
+
+    cap.run_neighbors_cycle = fake_cycle
+    _run(_drive_manual_cycle(cap))
+
+    assert ran == [1]
+    assert cap.should_exit is True
+    # --neighbors-exit must not leave a scheduler running behind it.
+    assert cap.neighbors_task is None
+
+
+def test_manual_trigger_without_exit_starts_scheduler(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    import time as _time
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.neighbors_run_now = True
+    ran = []
+
+    async def fake_cycle():
+        ran.append(1)
+        cap.last_neighbors_publish = _time.time()  # the real cycle stamps on success
+        return True
+
+    cap.run_neighbors_cycle = fake_cycle
+
+    async def scenario():
+        await _drive_manual_cycle(cap)
+        # Let the scheduler take its first pass; a just-stamped run is not due,
+        # so the manual cycle must not be immediately repeated.
+        await asyncio.sleep(0)
+        return cap.neighbors_task
+
+    task = _run(scenario())
+
+    assert ran == [1]
+    assert cap.should_exit is False
+    assert task is not None
+
+
+def test_manual_trigger_errors_when_no_broker_opted_in(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    monkeypatch.setenv("PACKETCAPTURE_IATA", "SEA")
+    monkeypatch.setenv("PACKETCAPTURE_DATA_DIR", str(tmp_path))
+    cap = PacketCapture(enable_mqtt=True)
+    cap.device_public_key = "ff" * 32
+    cap.neighbors_run_now = True
+    ran = []
+    cap.run_neighbors_cycle = lambda: ran.append(1)
+    errors = []
+    monkeypatch.setattr(cap.logger, "error", lambda m, **k: errors.append(m))
+
+    _run(_drive_manual_cycle(cap))
+
+    assert ran == []
+    assert any("no enabled broker has neighbors" in m for m in errors)
+
+
+def test_manual_trigger_survives_cycle_exception(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.neighbors_run_now = True
+    cap.neighbors_exit_after_run = True
+
+    async def boom():
+        raise RuntimeError("radio unplugged")
+
+    cap.run_neighbors_cycle = boom
+    errors = []
+    monkeypatch.setattr(cap.logger, "error", lambda m, **k: errors.append(m))
+
+    _run(_drive_manual_cycle(cap))   # must not propagate
+
+    assert any("manual cycle failed" in m for m in errors)
+    # Still honours --neighbors-exit so a scripted test run terminates.
+    assert cap.should_exit is True
+
+
+# --------------------------------------------------------------------------
+# Failure modes found on real hardware
+# --------------------------------------------------------------------------
+
+def test_discover_bounded_when_send_never_returns():
+    """A stalled link must not hang the cycle (and, for --neighbors-now, startup).
+
+    The BLE/serial write inside send() can block far longer than the library's
+    own response timeout; observed as a >3 minute stall on real hardware.
+    """
+    class HangingMeshCore:
+        def __init__(self):
+            class Commands:
+                async def send_node_discover_req(s, *a, **k):
+                    # A never-resolving future, not sleep(): the autouse fixture
+                    # patches asyncio.sleep module-wide, which would make a
+                    # sleep-based fake return instantly.
+                    await asyncio.Event().wait()
+
+            self.commands = Commands()
+            self.unsubscribed = []
+
+        def subscribe(self, et, handler):
+            return "sub"
+
+        def unsubscribe(self, sub):
+            self.unsubscribed.append(sub)
+
+    mc = HangingMeshCore()
+    cfg = nb.NeighborsConfig(command_timeout=0.05)
+    logger = _FakeLogger()
+
+    async def scenario():
+        # Real sleep so wait_for can actually fire.
+        return await nb.discover_neighbors(mc, cfg, None, logger)
+
+    result = asyncio.run(scenario())
+
+    assert result is None
+    assert any("did not complete within" in m for m in logger.messages)
+    # Must still unsubscribe on the timeout path.
+    assert mc.unsubscribed == ["sub"]
+
+
+def test_discover_aborts_when_session_reset_midwindow():
+    """A reconnect clears every subscription, so the handler stops firing.
+
+    Publishing the (now empty) collection would assert the mesh has no
+    neighbours when in fact we simply stopped listening.
+    """
+    mc = _DiscoverMeshCore([_resp("aa" * 32, 5.0)])
+    logger = _FakeLogger()
+
+    result = _run(
+        nb.discover_neighbors(
+            mc, nb.NeighborsConfig(), None, logger, still_valid=lambda: False
+        )
+    )
+
+    assert result is None
+    assert any("session was reset" in m for m in logger.messages)
+
+
+def test_discover_proceeds_while_session_intact():
+    mc = _DiscoverMeshCore([_resp("aa" * 32, 5.0)])
+    entries = _run(
+        nb.discover_neighbors(
+            mc, nb.NeighborsConfig(), None, _FakeLogger(), still_valid=lambda: True
+        )
+    )
+    assert [e.pubkey for e in entries] == ["aa" * 32]
+
+
+def test_cycle_discards_result_when_session_reset_during_scopes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    """Scopes gathered against a dead session must not be published."""
+    cap = _cycle_capture(monkeypatch, tmp_path, {"aa" * 32: "DEN"})
+    published = []
+    cap.safe_publish = lambda *a, **k: published.append(1) or {"attempted": 1, "succeeded": 1}
+
+    original_collect = nb.collect_scopes
+
+    async def collect_then_reconnect(*a, **k):
+        await original_collect(*a, **k)
+        cap.meshcore = _CycleMeshCore({})   # simulate reconnect swapping the object
+
+    monkeypatch.setattr(pc_mod, "collect_scopes", collect_then_reconnect)
+
+    assert _run(cap.run_neighbors_cycle()) is False
+    assert published == []
+
+
+def test_command_timeout_is_configurable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PACKETCAPTURE_NEIGHBORS_COMMAND_TIMEOUT", "7.5")
+    cap = PacketCapture(enable_mqtt=False)
+    assert cap.neighbors_config.command_timeout == 7.5
+
+
+def test_every_neighbors_config_field_is_reachable_from_toml():
+    """Guard against re-introducing dead config (as neighbors_retry_limit was).
+
+    Every NeighborsConfig field must survive the TOML -> env -> PacketCapture
+    round trip, or it is a knob documented in config.toml.example that silently
+    does nothing.
+    """
+    import dataclasses
+    from meshcore_packet_capture import config_loader as cl
+
+    toml_name = {"max_neighbors": "neighbors_max"}
+    capture = {}
+    for field in dataclasses.fields(nb.NeighborsConfig):
+        key = toml_name.get(field.name, f"neighbors_{field.name}")
+        capture[key] = "DEN" if field.name == "self_scopes" else 13
+
+    env = cl.flatten_config_to_env_dict({"capture": capture})
+    missing = [k for k in capture if not any(
+        e.startswith("PACKETCAPTURE_NEIGHBORS_") and env[e] in ("13", "DEN")
+        and e.endswith(k.replace("neighbors_", "").upper()) for e in env)]
+    assert not missing, f"not settable from config: {missing}"
+
+
+# --------------------------------------------------------------------------
+# Device-command serialisation (concurrent BLE writes drop the link)
+# --------------------------------------------------------------------------
+
+def test_collect_scopes_holds_lock_per_request_not_whole_pass():
+    """The lock must be released between neighbours.
+
+    A scope pass can span minutes; holding the lock throughout would stall the
+    app's status publishes and health checks for its whole duration.
+    """
+    entries = [_entry("a", 1.0, 100.0), _entry("b", 1.0, 90.0)]
+    mc = _FakeMeshCore({e.pubkey: "S" for e in entries})
+    lock = asyncio.Lock()
+    held = []
+
+    original = mc.commands.req_regions_sync
+
+    async def watching(pubkey, timeout=0, min_timeout=0):
+        held.append(lock.locked())
+        return await original(pubkey, timeout=timeout, min_timeout=min_timeout)
+
+    mc.commands.req_regions_sync = watching
+
+    async def scenario():
+        await nb.collect_scopes(
+            mc, entries, nb.NeighborsConfig(scope_gap=0.0), _FakeLogger(),
+            command_lock=lock,
+        )
+        return lock.locked()
+
+    still_locked = asyncio.run(scenario())
+    assert held == [True, True]      # held during each request
+    assert still_locked is False     # released afterwards
+
+
+def test_discover_holds_lock_for_the_send():
+    mc = _DiscoverMeshCore([])
+    lock = asyncio.Lock()
+    seen = []
+    original = mc.commands.send_node_discover_req
+
+    async def watching(*a, **k):
+        seen.append(lock.locked())
+        return await original(*a, **k)
+
+    mc.commands.send_node_discover_req = watching
+    _run(nb.discover_neighbors(mc, nb.NeighborsConfig(), None, _FakeLogger(),
+                               command_lock=lock))
+    assert seen == [True]
+    assert lock.locked() is False
+
+
+def test_neighbors_functions_work_without_a_lock():
+    """command_lock is optional; omitting it must not break anything."""
+    entry = _entry("a", 1.0, 100.0)
+    mc = _FakeMeshCore({entry.pubkey: "DEN"})
+    _run(nb.collect_scopes(mc, [entry], nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
+    assert entry.status == nb.STATUS_RESPONDED
+
+
+# --------------------------------------------------------------------------
+# Device lock: neighbors-side usage
+# --------------------------------------------------------------------------
+
+def test_scope_request_is_bounded_while_holding_the_lock(monkeypatch: pytest.MonkeyPatch):
+    """An unbounded scope request would wedge the shared lock (and the watchdog)."""
+    entry = _entry("a", 1.0, 100.0)
+    lock = pc_mod.TaskReentrantLock()
+
+    class Stalling:
+        calls = []
+
+        async def req_regions_sync(self, pubkey, timeout=0, min_timeout=0):
+            self.calls.append(pubkey)
+            await asyncio.Event().wait()          # never returns
+
+    class MC:
+        def __init__(self):
+            self.commands = Stalling()
+            self._contacts = {}
+
+        @property
+        def contacts(self):
+            return self._contacts
+
+    mc = MC()
+    # Shrink the MSG_SENT allowance so the real budget is exercised quickly.
+    monkeypatch.setattr(nb, "LIBRARY_MSG_SENT_TIMEOUT", 0.05)
+    cfg = nb.NeighborsConfig(scope_gap=0.0, scope_min_timeout=0.05, command_timeout=1.0)
+    logger = _FakeLogger()
+
+    async def scenario():
+        await asyncio.wait_for(
+            nb.collect_scopes(mc, [entry], cfg, logger, command_lock=lock), timeout=60.0
+        )
+        return lock.locked()
+
+    still_locked = asyncio.run(scenario())
+    assert entry.status == nb.STATUS_SEND_FAILED
+    assert still_locked is False
+    assert any("may be stalled" in m for m in logger.messages)
+
+
+def test_command_timeout_zero_is_floored():
+    """0 reads as 'no cap' beside scope_timeout, but wait_for(0) fails instantly."""
+    assert nb.NeighborsConfig(command_timeout=0).command_timeout == nb.MIN_COMMAND_TIMEOUT
+    assert nb.NeighborsConfig(command_timeout=-5).command_timeout == nb.MIN_COMMAND_TIMEOUT
+
+
+def test_manual_cycle_is_bounded_by_its_budget(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """--neighbors-now runs inline before the main loop; an unbounded stall
+    there hangs startup outright (observed on hardware before this bound)."""
+    cap = _cycle_capture(monkeypatch, tmp_path, {})
+    cap.neighbors_run_now = True
+    cap.neighbors_exit_after_run = True
+    # Every term feeds the budget, so shrink the floors too or this test would
+    # have to wait out the real ~18s minimum.
+    monkeypatch.setattr(nb, "MIN_DISCOVER_WINDOW", 0.01)
+    monkeypatch.setattr(nb, "MIN_CYCLE_TIMEOUT", 0.01)
+    monkeypatch.setattr(nb, "MIN_COMMAND_TIMEOUT", 0.01)
+    monkeypatch.setattr(nb, "LIBRARY_MSG_SENT_TIMEOUT", 0.01)
+    cap.neighbors_config = nb.NeighborsConfig(
+        discover_window=0, command_timeout=0, cycle_timeout=0,
+        scope_min_timeout=0.01, scope_gap=0,
+    )
+
+    async def hangs():
+        await asyncio.Event().wait()
+
+    cap.run_neighbors_cycle = hangs
+    errors = []
+    monkeypatch.setattr(cap.logger, "error", lambda m, **k: errors.append(m))
+
+    _run(asyncio.wait_for(cap.run_manual_neighbors_cycle(), timeout=90))
+
+    assert any("was abandoned" in m for m in errors)
+    assert cap.should_exit is True     # --neighbors-exit still honoured
+
+
+def test_cycle_truncates_to_max_neighbors(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Without the cap a large mesh would be queried without bound."""
+    scopes = {f"{i:02x}" * 32: "DEN" for i in range(6)}
+    cap = _cycle_capture(monkeypatch, tmp_path, scopes)
+    cap.neighbors_config = nb.NeighborsConfig(
+        discover_window=0, scope_gap=0, max_neighbors=2
+    )
+    published = []
+    cap.safe_publish = lambda topic, payload, retain=False, **kw: (
+        published.append(json.loads(payload)) or {"attempted": 1, "succeeded": 1}
+    )
+    _run(cap.run_neighbors_cycle())
+    assert len(published[0]["neighbors"]) == 2
+
+
+def test_collect_scopes_paces_requests_with_the_gap():
+    """scope_gap is the anti-collision mechanism from firmware commit aba571ed."""
+    entries = [_entry("a", 1.0, 100.0), _entry("b", 1.0, 90.0), _entry("c", 1.0, 80.0)]
+    mc = _FakeMeshCore({e.pubkey: "S" for e in entries})
+    slept = []
+
+    async def record(seconds):
+        slept.append(seconds)
+
+    async def scenario():
+        import meshcore_packet_capture.neighbors as mod
+        real = mod.asyncio.sleep
+        mod.asyncio.sleep = record
+        try:
+            await nb.collect_scopes(
+                mc, entries, nb.NeighborsConfig(scope_gap=2.0), _FakeLogger()
+            )
+        finally:
+            mod.asyncio.sleep = real
+
+    asyncio.run(scenario())
+    # One gap between each pair, none before the first.
+    assert slept == [2.0, 2.0]
+
+
+def test_neighbors_config_env_wiring_reaches_the_instance(monkeypatch: pytest.MonkeyPatch):
+    """TOML->env is not enough; __init__ must actually read each key."""
+    for key, val in [
+        ("NEIGHBORS_DISCOVER_WINDOW", "31"), ("NEIGHBORS_COMMAND_TIMEOUT", "32"),
+        ("NEIGHBORS_SCOPE_TIMEOUT", "33"), ("NEIGHBORS_SCOPE_MIN_TIMEOUT", "34"),
+        ("NEIGHBORS_SCOPE_GAP", "35"), ("NEIGHBORS_CYCLE_TIMEOUT", "36"),
+        ("NEIGHBORS_MAX", "37"),
+    ]:
+        monkeypatch.setenv(f"PACKETCAPTURE_{key}", val)
+    cfg = PacketCapture(enable_mqtt=False).neighbors_config
+    assert cfg.discover_window == 31
+    assert cfg.command_timeout == 32
+    assert cfg.scope_timeout == 33
+    assert cfg.scope_min_timeout == 34
+    assert cfg.scope_gap == 35
+    assert cfg.cycle_timeout == 36
+    assert cfg.max_neighbors == 37
+
+
+def test_cycle_passes_the_device_lock_to_every_stage(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """The lock wiring is the whole hardware-driven fix; assert it is threaded."""
+    cap = _cycle_capture(monkeypatch, tmp_path, {"aa" * 32: "DEN"})
+    seen = {}
+
+    async def fake_discover(mc, cfg, pk, logger, **kw):
+        seen["discover"] = kw.get("command_lock")
+        return [_entry("a", 1.0, 100.0)]
+
+    async def fake_collect(mc, entries, cfg, logger, **kw):
+        seen["collect"] = kw.get("command_lock")
+
+    async def fake_self_scopes(mc, cfg, logger, command_lock=None):
+        seen["self_scopes"] = command_lock
+        return ""
+
+    monkeypatch.setattr(pc_mod, "discover_neighbors", fake_discover)
+    monkeypatch.setattr(pc_mod, "collect_scopes", fake_collect)
+    monkeypatch.setattr(pc_mod, "fetch_self_scopes", fake_self_scopes)
+    cap.safe_publish = lambda *a, **k: {"attempted": 1, "succeeded": 1}
+
+    _run(cap.run_neighbors_cycle())
+
+    assert seen["discover"] is cap.device_command_lock
+    assert seen["collect"] is cap.device_command_lock
+    assert seen["self_scopes"] is cap.device_command_lock
+
+
+async def _drive_manual_cycle(cap):
+    """Invoke the real production path, then the real scheduler launch."""
+    await cap.run_manual_neighbors_cycle()
+    if (not cap.should_exit and cap.enable_mqtt
+            and cap.neighbors_broker_nums(warn_unroutable=True)):
+        cap.neighbors_task = asyncio.create_task(cap.neighbors_scheduler())
+
+
+def test_truncated_flag_set_by_payload_budget():
+    entries = [
+        nb.NeighborEntry(pubkey=f"{i:02x}" * 32, snr=0.0, heard_at=float(i), scopes="X" * 40)
+        for i in range(40)
+    ]
+    message, dropped = nb.build_neighbors_message(
+        "o", "id", "", entries, timestamp="T", now=100.0, budget=1024
+    )
+    assert dropped > 0
+    assert message["truncated"] is True
+    assert message["queried_neighbors"] == 40
+    assert len(message["neighbors"]) == 40 - dropped
+
+
+def test_truncated_flag_set_by_max_neighbors_cap():
+    """total_neighbors reports the pre-cap count, so consumers can see the cap."""
+    entries = [nb.NeighborEntry(pubkey="11" * 32, snr=1.0, heard_at=1.0)]
+    message, dropped = nb.build_neighbors_message(
+        "o", "id", "", entries, timestamp="T", now=1.0, total_neighbors=9
+    )
+    assert dropped == 0
+    assert message["total_neighbors"] == 9
+    assert message["queried_neighbors"] == 1
+    assert message["truncated"] is True

--- a/tests/packet_capture/test_neighbors.py
+++ b/tests/packet_capture/test_neighbors.py
@@ -121,7 +121,7 @@ def test_budget_not_applied_when_payload_fits():
 
 
 # --------------------------------------------------------------------------
-# Zero-hop contact override (the mechanism from plan section 3.1)
+# Shared helpers
 # --------------------------------------------------------------------------
 
 class _FakeLogger:
@@ -132,64 +132,6 @@ class _FakeLogger:
         self.messages.append(str(msg))
 
     debug = info = warning = error = _record
-
-
-def test_zero_hop_contact_is_direct_with_empty_path():
-    contact = nb._zero_hop_contact("aa" * 32)
-    # out_path_len == 0 keeps meshcore_py off its out_path_len == -1 branch, so it
-    # issues no change_contact_path/reset_path writes to the device.
-    assert contact["out_path_len"] == 0
-    assert contact["out_path"] == ""
-    assert contact["public_key"] == "aa" * 32
-
-
-class _ContactCacheMeshCore:
-    """Mirrors MeshCore: `contacts` is a property returning the live dict."""
-
-    def __init__(self, initial=None):
-        self._contacts = dict(initial or {})
-
-    @property
-    def contacts(self):
-        return self._contacts
-
-
-def test_override_injects_then_removes_when_no_prior_contact():
-    mc = _ContactCacheMeshCore()
-    key = "bb" * 32
-    with nb.zero_hop_contact_override(mc, key, _FakeLogger()) as ok:
-        assert ok is True
-        assert mc._contacts[key]["out_path_len"] == 0
-    assert key not in mc._contacts
-
-
-def test_override_restores_preexisting_contact_exactly():
-    key = "cc" * 32
-    real = {"public_key": key, "out_path_len": 3, "out_path": "aabbcc", "adv_name": "repeater"}
-    mc = _ContactCacheMeshCore({key: real})
-    with nb.zero_hop_contact_override(mc, key, _FakeLogger()):
-        # A stale multi-hop path must not route the probe the long way.
-        assert mc._contacts[key]["out_path_len"] == 0
-    assert mc._contacts[key] is real
-    assert mc._contacts[key]["out_path_len"] == 3
-
-
-def test_override_restores_even_when_body_raises():
-    key = "dd" * 32
-    real = {"public_key": key, "out_path_len": 2, "out_path": "1122"}
-    mc = _ContactCacheMeshCore({key: real})
-    with pytest.raises(RuntimeError):
-        with nb.zero_hop_contact_override(mc, key, _FakeLogger()):
-            raise RuntimeError("scope request blew up")
-    assert mc._contacts[key] is real
-
-
-def test_override_reports_false_without_contact_cache():
-    class FakeMeshCore:
-        pass
-
-    with nb.zero_hop_contact_override(FakeMeshCore(), "ee" * 32, _FakeLogger()) as ok:
-        assert ok is False
 
 
 # --------------------------------------------------------------------------
@@ -256,26 +198,6 @@ def test_collect_scopes_assigns_statuses():
     assert (responded.status, responded.scopes) == (nb.STATUS_RESPONDED, "DEN,APRS")
     # None covers a real timeout and a device-level rejection alike.
     assert timed_out.status == nb.STATUS_TIMEOUT
-
-
-def test_collect_scopes_reports_send_failed_when_no_contact_cache():
-    """No contact cache means nothing was transmitted at all.
-
-    Reporting that as a timeout would assert on the topic that the neighbor was
-    asked and stayed silent, when in fact no frame ever left the radio.
-    """
-    class NoCacheMeshCore:
-        def __init__(self):
-            self.commands = _FakeCommands({})
-
-    entry = _entry("a", 5.0, 100.0)
-    mc = NoCacheMeshCore()
-    logger = _FakeLogger()
-    _run(nb.collect_scopes(mc, [entry], nb.NeighborsConfig(scope_gap=0.0), logger))
-
-    assert entry.status == nb.STATUS_SEND_FAILED
-    assert mc.commands.calls == []
-    assert any("contact cache unavailable" in m for m in logger.messages)
 
 
 def test_collect_scopes_reports_send_failed_on_transport_exception():
@@ -356,7 +278,16 @@ def test_collect_scopes_handles_empty_list():
     assert mc.commands.calls == []
 
 
-def test_collect_scopes_leaves_contact_cache_clean():
+def test_collect_scopes_never_populates_contact_cache():
+    """Neighbors must stay unknown to the library's contact cache.
+
+    send_anon_req only requests a zero-hop direct reply path when the
+    destination is not a known contact. A neighbor that appeared in the cache
+    carrying a stale multi-hop out_path would have its scope query routed the
+    long way instead of probed directly, silently breaking firmware parity --
+    so the cache staying empty is load-bearing, not incidental. Holds on the
+    error path too.
+    """
     entries = [_entry("a", 1.0, 100.0), _entry("b", 1.0, 90.0)]
     mc = _FakeMeshCore({entries[0].pubkey: "S", entries[1].pubkey: RuntimeError("boom")})
     _run(nb.collect_scopes(mc, entries, nb.NeighborsConfig(scope_gap=0.0), _FakeLogger()))
@@ -1016,7 +947,10 @@ class _CycleMeshCore:
                 return _FakeEvent("OK", {"tag": tag})
 
             async def req_regions_sync(s, pubkey, timeout=0, min_timeout=0):
-                assert outer._contacts[pubkey]["out_path_len"] == 0
+                # The neighbor must NOT be a known contact: that is exactly what
+                # makes send_anon_req (>= 2.3.8) request a zero-hop direct reply
+                # path, which is the firmware-parity behaviour we want.
+                assert pubkey not in outer._contacts
                 return scopes[pubkey]
 
             async def get_default_flood_scope(s):

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -215,3 +215,55 @@ def test_capture_extended_keys_mapped():
     assert env["PACKETCAPTURE_BINARY_INTERFACE_PORT"] == "5001"
     assert env["PACKETCAPTURE_OWNER_PUBLIC_KEY"] == "ABC"
     assert env["PACKETCAPTURE_OWNER_EMAIL"] == "u@example.com"
+
+
+def test_flatten_neighbors_capture_settings():
+    cfg = {
+        "capture": {
+            "neighbors_interval_hours": 48,
+            "neighbors_discover_window": 90.0,
+            "neighbors_command_timeout": 25.0,
+            "neighbors_scope_timeout": 0.0,
+            "neighbors_scope_min_timeout": 8.0,
+            "neighbors_scope_gap": 2.5,
+            "neighbors_cycle_timeout": 900,
+            "neighbors_max": 16,
+            "neighbors_self_scopes": "DEN,APRS",
+        }
+    }
+    env = cl.flatten_config_to_env_dict(cfg)
+    assert env["PACKETCAPTURE_NEIGHBORS_INTERVAL_HOURS"] == "48"
+    assert env["PACKETCAPTURE_NEIGHBORS_DISCOVER_WINDOW"] == "90.0"
+    assert env["PACKETCAPTURE_NEIGHBORS_COMMAND_TIMEOUT"] == "25.0"
+    assert env["PACKETCAPTURE_NEIGHBORS_SCOPE_TIMEOUT"] == "0.0"
+    assert env["PACKETCAPTURE_NEIGHBORS_SCOPE_MIN_TIMEOUT"] == "8.0"
+    assert env["PACKETCAPTURE_NEIGHBORS_SCOPE_GAP"] == "2.5"
+    assert env["PACKETCAPTURE_NEIGHBORS_CYCLE_TIMEOUT"] == "900"
+    assert env["PACKETCAPTURE_NEIGHBORS_MAX"] == "16"
+    assert env["PACKETCAPTURE_NEIGHBORS_SELF_SCOPES"] == "DEN,APRS"
+
+
+def test_flatten_per_broker_neighbors_flag_and_topic():
+    cfg = {
+        "broker": [
+            {
+                "name": "analyzer",
+                "enabled": True,
+                "server": "mqtt.example",
+                "neighbors": True,
+                "topics": {"neighbors": "custom/{IATA}/{PUBLIC_KEY}/neighbors"},
+            },
+            {"name": "plain", "enabled": True, "server": "other.example"},
+        ]
+    }
+    env = cl.flatten_config_to_env_dict(cfg)
+    assert env["PACKETCAPTURE_MQTT1_NEIGHBORS"] == "true"
+    assert env["PACKETCAPTURE_MQTT1_TOPIC_NEIGHBORS"] == "custom/{IATA}/{PUBLIC_KEY}/neighbors"
+    # Unset means off: no key emitted, so the runtime default (off) applies.
+    assert "PACKETCAPTURE_MQTT2_NEIGHBORS" not in env
+
+
+def test_flatten_per_broker_neighbors_explicit_false():
+    cfg = {"broker": [{"name": "a", "enabled": True, "neighbors": False}]}
+    env = cl.flatten_config_to_env_dict(cfg)
+    assert env["PACKETCAPTURE_MQTT1_NEIGHBORS"] == "false"

--- a/tests/test_jwt_renewal.py
+++ b/tests/test_jwt_renewal.py
@@ -164,6 +164,9 @@ async def test_jwt_uses_broker_specific_owner_email(monkeypatch: pytest.MonkeyPa
         get_env=lambda key, default="": cap._env.get(key, default),
         resolve_token_ttl=lambda broker_num: 3600,
         _load_client_version=lambda: "meshcore-packet-capture/test",
+        # JWT signing is a multi-frame device sequence and is held under the
+        # device lock, so the stand-in needs one too.
+        device_command_lock=pc_mod.TaskReentrantLock(),
     )
 
     async def _create_jwt_with_private_key(audience, expiry_seconds=86400, broker_num=None):
@@ -215,6 +218,9 @@ async def test_jwt_owner_email_falls_back_to_global(monkeypatch: pytest.MonkeyPa
         get_env=lambda key, default="": cap._env.get(key, default),
         resolve_token_ttl=lambda broker_num: 3600,
         _load_client_version=lambda: "meshcore-packet-capture/test",
+        # JWT signing is a multi-frame device sequence and is held under the
+        # device lock, so the stand-in needs one too.
+        device_command_lock=pc_mod.TaskReentrantLock(),
     )
 
     await PacketCapture.create_jwt_with_private_key(


### PR DESCRIPTION
Port of the observer firmware's `WITH_MQTT_NEIGHBORS` feature, plus a device-command
fix that came out of testing it on hardware, plus the cleanup after both of this
work's library-side asks landed upstream. Three commits; the first stands alone.

## Serialise device commands

Two overlapping writes to the BLE RX characteristic kill the connection.
Reproduced by issuing `send_device_query()` and `send_node_discover_req()`
concurrently: `BLE write failed: 19`, link gone, command hung >45s. Issued
sequentially the same two take 0.09s each and are fine, so it is the overlap.

Nothing guaranteed callers were sequential — the connection monitor, stats
refresh, advert scheduler, JWT renewal and user commands all issue
independently. All device commands now funnel through one lock.
`retryable_device_command` covers most call sites; `send_advert` and the JWT
signing sequence did not go through it and are wrapped explicitly. Signing is
held as a unit, since another command writing between two `sign_data` chunks is
exactly the overlap that breaks the link.

The lock is task-reentrant — JWT creation holds it across signing and its
private-key fallback re-enters through `retryable_device_command`, which
deadlocks a plain `asyncio.Lock`. Acquisition is bounded, so a stalled holder
cannot block the connection watchdog, whose own timeout cannot fire while it is
still queued.

## Neighbors publishing

On a long interval, ask which repeaters this node hears directly, ask each for
its region scopes, and publish to a `neighbors` topic matching the firmware's
JSON contract.

Off by default, opted into per broker with `neighbors = true`, since not every
broker accepts the topic. The cycle runs only when at least one enabled broker
has opted in *and* its topic resolves — otherwise it would spend a discover
window plus one on-air request per neighbour and discard the result.

Both requests come from `meshcore_py` (`send_node_discover_req`,
`req_regions_sync`); nothing here re-encodes packets.

Pacing follows firmware commit `aba571ed`, which moved from firing every scope
request at once to one at a time after the responses collided. Entries are
sorted by usefulness before querying, so a truncated cycle still covers the most
useful neighbours; each request is bounded and holds the shared device lock only
for its own duration, since a pass can span minutes.

`--neighbors-now` runs one cycle immediately — the 12h minimum interval makes
waiting impractical for testing — and `--neighbors-exit` quits after.

## Pin meshcore 2.3.8, drop the shim

Both library-side gaps this feature ran into were fixed upstream and released in
2.3.8, so the workarounds come out and the floor moves up.

`send_anon_req` now requests a zero-hop direct reply path when the destination is
not a known contact — the firmware has never needed one, since
`FIRMWARE_VER_CODE 13` it synthesises a transient contact itself. That is exactly
what the contact-cache injection shim was forcing, so `_zero_hop_contact()` and
`zero_hop_contact_override()` are deleted and `req_regions_sync` is called
verbatim.

One consequence is now load-bearing rather than incidental: upstream picks the
zero-hop path only when the contact is *absent*, so a neighbour present in the
cache with a stale multi-hop `out_path` would have its scope query routed the
long way instead. Nothing here populates that cache — nothing calls
`ensure_contacts()`, and `auto_update_contacts` defaults to False — so the
property still holds, but it is now an invariant to preserve rather than
something enforced per request. A test pins it and `collect_scopes`' docstring
records it.

`ble_cx` gained an `asyncio.Lock` around `write_gatt_char` plus a 10s write
timeout, which is what stops two overlapping writes dropping the link. That
retires the first commit's justification for `device_command_lock`, so it was
re-examined rather than kept by inertia. It stays, guarding two things a
per-write lock structurally cannot: a command is a write *plus* a wait for its
reply, and `CommandHandler.send()` takes no lock while matching replies by event
type, so two in-flight commands can take each other's response; and multi-frame
sequences like on-device JWT signing have to be held as a unit. The stale
link-drop rationale is removed from all four sites and from the tests.

The pin moves in every install path — `requirements.txt`, `pyproject.toml`,
`installer/system.py`, `nix/packages.nix` and the README — since leaving any one
at 2.2.31 would install a library whose `send_anon_req` refuses the request,
making stage 2 report `timeout` for every neighbour with no RF sent.

## Hardware validation

Against a companion radio (fw ver 13, `v1.16.0-07a3ca9`) over BLE with a
loopback-only broker, so nothing reached a community broker.

Initial run: 6 neighbours discovered, 4 answering with real scopes, correct
ordering and status values. Three bugs that unit tests could not have found:

- The discover request was unbounded. A stalled BLE write hung for over three
  minutes — the library's timeout covers the wait for a reply, not the write —
  and since `--neighbors-now` runs inline in `start()`, that hung startup
  outright.
- A reconnect mid-cycle silently blinds the collector.
  `cleanup_event_subscriptions()` drops every subscription including the live
  discover handler, after which the cycle would publish "0 neighbours" as though
  the mesh were empty. A session-identity check now abandons it instead.
- Concurrent device writes drop the link — the first commit.

Re-validated on 2.3.8 with the shim gone. With the contact cache empty the
library logs `No contact found, requesting a zero-hop direct reply path` and
sends `0x39` + pubkey + `01` + `00` — the zero-hop probe the shim used to force —
and real scopes come back in 1.0–1.8s. Two end-to-end cycles published 4 and 6
neighbours with correct ordering, including SNR breaking a `heard_secs_ago` tie.
`device_query || discover`, the overlap that produced `BLE write failed: 19` and
a >45s hang, now returns both in 0.57s with the link healthy.

Measured and deliberately not changed: `req_regions_async` does not forward
`min_timeout` to `send_anon_req`, so with `scope_timeout = 0` the reader's
pending-request window is `suggested_timeout/800` (2.92s observed) while
`req_regions_sync` waits 8s. That reads like it would discard replies landing in
the gap, but replies arrive in 1.0–1.8s, far inside the shorter window, and an
A/B over four repeaters had the current default answer 4/4 against 2/4 for the
longer window. A latent upstream inconsistency, not a reason to retune — noted
so it does not get "fixed" on a code reading alone.

`status: "timeout"` entries are ordinary non-responses: the same repeater
answered in one cycle and timed out in the next. `self.scopes` is empty because
this radio has no default flood scope set — queried directly it returns
`DEFAULT_FLOOD_SCOPE` with an empty payload — which is the documented fallback;
`neighbors_self_scopes` overrides it.

## Notes

- 248 → 362 tests.
- `last_neighbors_publish` shares `advert_state.json`; both timestamps are merged
  rather than overwritten.
