### PR TITLE
feat(presets): enable neighbors publishing for chimesh

### DIFF
--- a/presets/chimesh.toml
+++ b/presets/chimesh.toml
@@ -7,6 +7,7 @@ transport = "websockets"
 keepalive = 55
 qos = 0
 retain = true
+neighbors = true
 
 [broker.tls]
 enabled = true


### PR DESCRIPTION
Adds `neighbors = true` to the chimesh `[[broker]]` block so the preset ships with the zero-hop neighbors snapshot on, instead of every chimesh operator adding the key by hand.

Stacked on `feat/mqtt-neighbors` (where the neighbors feature lives), not `main`.

## Why this is safe to default on

`neighbors_broker_nums()` only returns brokers whose neighbors topic actually resolves. The preset sets no IATA, so for an operator without a global `[capture] iata`, `get_topic('NEIGHBORS')` returns `None`, the broker is dropped with a warning, and no discover window or on-air scope requests are spent. Operators already publishing IATA-scoped topics get the snapshot on the default `meshcore/{IATA}/{PUBLIC_KEY}/neighbors` topic.

## Verification

- `flatten_config_to_env_dict` on the preset emits `PACKETCAPTURE_MQTT1_NEIGHBORS = true`
- `tests/test_presets_valid.py` + `tests/test_config_loader.py` — 37 passed
- `tests/packet_capture/test_neighbors.py` — 106 passed