### PR TITLE
Support per-broker WebSocket paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Brokers are discovered sequentially starting at `MQTT1` and continue until `PACK
 - `PACKETCAPTURE_MQTT1_PORT`: MQTT broker port
 - `PACKETCAPTURE_MQTT1_USERNAME`/`PACKETCAPTURE_MQTT1_PASSWORD`: Authentication credentials
 - `PACKETCAPTURE_MQTT1_TRANSPORT`: Transport type (`tcp` or `websockets`)
+- `PACKETCAPTURE_MQTT1_WEBSOCKET_PATH`: WebSocket endpoint path (default: `/`)
 - `PACKETCAPTURE_MQTT1_USE_TLS`: Enable TLS/SSL encryption
 - `PACKETCAPTURE_MQTT1_TLS_VERIFY`: Verify TLS certificates (default: true)
 - `PACKETCAPTURE_MQTT1_USE_AUTH_TOKEN`: Use auth token authentication

--- a/config.toml.example
+++ b/config.toml.example
@@ -104,6 +104,7 @@ rf_data_timeout = 15.0
 # server = "mqtt.example.com"
 # port = 1883
 # transport = "tcp"
+# websocket_path = "/" # Optional WebSocket endpoint path; ignored for TCP
 # keepalive = 60
 # qos = 0
 # retain = true

--- a/presets/meshomatic.toml
+++ b/presets/meshomatic.toml
@@ -4,6 +4,7 @@ enabled = true
 server = "us-east.meshomatic.net"
 port = 443
 transport = "websockets"
+websocket_path = "/mqtt"
 keepalive = 55
 qos = 0
 retain = true

--- a/src/meshcore_packet_capture/config_loader.py
+++ b/src/meshcore_packet_capture/config_loader.py
@@ -126,6 +126,8 @@ def _broker_to_env_slot(broker: dict[str, Any], slot: int) -> dict[str, str]:
         out[prefix + "PORT"] = str(int(broker["port"]))
     if "transport" in broker:
         out[prefix + "TRANSPORT"] = str(broker["transport"])
+    if "websocket_path" in broker:
+        out[prefix + "WEBSOCKET_PATH"] = str(broker["websocket_path"])
     if "keepalive" in broker:
         out[prefix + "KEEPALIVE"] = str(int(broker["keepalive"]))
     if "qos" in broker:

--- a/src/meshcore_packet_capture/packet_capture.py
+++ b/src/meshcore_packet_capture/packet_capture.py
@@ -2717,8 +2717,9 @@ class PacketCapture:
             
             # Handle WebSocket transport
             if transport == "websockets":
+                websocket_path = self.get_env(f'MQTT{broker_num}_WEBSOCKET_PATH', '/')
                 mqtt_client.ws_set_options(
-                    path="/",
+                    path=websocket_path,
                     headers=None
                 )
             

--- a/tests/packet_capture/test_core_behavior.py
+++ b/tests/packet_capture/test_core_behavior.py
@@ -111,6 +111,61 @@ async def test_connect_passes_configured_ble_pin(
 
 
 @pytest.mark.asyncio
+async def test_connect_mqtt_broker_uses_configured_websocket_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capture: PacketCapture,
+) -> None:
+    clients = []
+
+    class _MQTTClient:
+        def __init__(self, *_args, **_kwargs):
+            self.websocket_path = None
+            clients.append(self)
+
+        def enable_logger(self, _logger):
+            pass
+
+        def reconnect_delay_set(self, **_kwargs):
+            pass
+
+        def user_data_set(self, _data):
+            pass
+
+        def will_set(self, *_args, **_kwargs):
+            pass
+
+        def ws_set_options(self, *, path, headers):
+            self.websocket_path = path
+
+        def connect(self, *_args, **_kwargs):
+            pass
+
+        def loop_start(self):
+            pass
+
+    monkeypatch.setattr(pc_mod.mqtt, "Client", _MQTTClient, raising=False)
+    monkeypatch.setattr(
+        pc_mod.mqtt,
+        "CallbackAPIVersion",
+        types.SimpleNamespace(VERSION2=2),
+        raising=False,
+    )
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_ENABLED", "true")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_SERVER", "mqtt.example.com")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_PORT", "443")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_TRANSPORT", "websockets")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_WEBSOCKET_PATH", "/mqtt")
+    monkeypatch.setenv("PACKETCAPTURE_MQTT1_USE_TLS", "false")
+    capture.device_name = "test"
+    capture.device_public_key = "ABCDEF"
+
+    result = await capture.connect_mqtt_broker(1)
+
+    assert result is not None
+    assert clients[0].websocket_path == "/mqtt"
+
+
+@pytest.mark.asyncio
 async def test_wait_with_shutdown_event_returns_true(capture: PacketCapture) -> None:
     capture.shutdown_event = asyncio.Event()
     capture.shutdown_event.set()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -43,6 +43,7 @@ def test_flatten_brokers_to_mqtt_slots():
                 "server": "wss.example",
                 "port": 443,
                 "transport": "websockets",
+                "websocket_path": "/mqtt",
                 "tls": {"enabled": True, "verify": True},
                 "auth": {"method": "token", "audience": "aud"},
             },
@@ -52,6 +53,7 @@ def test_flatten_brokers_to_mqtt_slots():
     assert env["PACKETCAPTURE_MQTT1_SERVER"] == "mqtt.example"
     assert env["PACKETCAPTURE_MQTT1_NAME"] == "one"
     assert env["PACKETCAPTURE_MQTT2_NAME"] == "two"
+    assert env["PACKETCAPTURE_MQTT2_WEBSOCKET_PATH"] == "/mqtt"
     assert env["PACKETCAPTURE_MQTT2_USE_TLS"] == "true"
     assert env["PACKETCAPTURE_MQTT2_USE_AUTH_TOKEN"] == "true"
     assert env["PACKETCAPTURE_MQTT2_TOKEN_AUDIENCE"] == "aud"


### PR DESCRIPTION
## Summary

Adds support for configuring a custom WebSocket path for each MQTT broker. This fixes the MeshOMatic preset, which requires connections through `/mqtt` instead of the previously hardcoded `/` path.

Existing brokers remain unaffected because the default path is still `/`. Documentation and tests have also been updated.
