### PR TITLE
Add MeshCore CZ MQTT preset

### DIFF
--- a/presets/czechmesh.toml
+++ b/presets/czechmesh.toml
@@ -1,0 +1,42 @@
+[[broker]]
+name = "MQTT1 Czech"
+enabled = true
+server = "mqtt1.meshcore.cz"
+port = 443
+transport = "websockets"
+keepalive = 120
+qos = 0
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt1.meshcore.cz"
+
+[broker.topics]
+status = "meshcore/{IATA}/{PUBLIC_KEY}/status"
+packets = "meshcore/{IATA}/{PUBLIC_KEY}/packets"
+
+
+[[broker]]
+name = "MQTT2 Czech"
+enabled = true
+server = "mqtt2.meshcore.website"
+port = 443
+transport = "websockets"
+keepalive = 120
+qos = 0
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt2.meshcore.website"
+
+[broker.topics]
+status = "meshcore/{IATA}/{PUBLIC_KEY}/status"
+packets = "meshcore/{IATA}/{PUBLIC_KEY}/packets"


### PR DESCRIPTION
Adds a preset for the Czech MeshCore community MQTT cluster.

The cluster currently consists of two independent MQTT endpoints:

mqtt1.meshcore.cz
mqtt2.meshcore.website

Both endpoints use secure WebSocket connections on port 443 with token authentication.

The Czech MQTT cluster is also documented as part of the official MeshCore CZ wiki:

https://meshcore.cz/mapa_meshcore

Configuration details are available at:

https://mqtt1.meshcore.cz/mesh/en/